### PR TITLE
Add/update Class and Property comment annotations; remove all reference to equivalencies

### DIFF
--- a/caliper-jsonld.owl
+++ b/caliper-jsonld.owl
@@ -1135,13 +1135,14 @@
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/attempt",
   "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "The associated Attempt."
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid1"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "The associated Attempt."
-  }, {
     "@language" : "en",
     "@value" : "attempt"
   } ],
@@ -1191,9 +1192,6 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/CourseSection"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
-    "@value" : "caliper:"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",

--- a/caliper-rdfxml.owl
+++ b/caliper-rdfxml.owl
@@ -151,7 +151,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
             </owl:Class>
         </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
-        <rdfs:label xml:lang="en">The associated Attempt.</rdfs:label>
+        <rdfs:comment xml:lang="en">The associated Attempt.</rdfs:comment>
         <rdfs:label xml:lang="en">attempt</rdfs:label>
     </owl:ObjectProperty>
     
@@ -576,7 +576,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseSection"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain-text descriptor that characterizes the purpose of the CourseSection such as &quot;lecture&quot;, &quot;lab&quot; or &quot;seminar&quot;.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">caliper:</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">category</rdfs:label>
     </owl:DatatypeProperty>
     

--- a/caliper-turtle.owl
+++ b/caliper-turtle.owl
@@ -99,8 +99,8 @@ xsd:duration rdf:type rdfs:Datatype .
                                    )
                      ] ;
          rdfs:range :Attempt ;
-         rdfs:label "The associated Attempt."@en ,
-                    "attempt"@en .
+         rdfs:comment "The associated Attempt."@en ;
+         rdfs:label "attempt"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/creators
@@ -406,7 +406,6 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :CourseSection ;
           rdfs:range xsd:string ;
           rdfs:comment "A plain-text descriptor that characterizes the purpose of the CourseSection such as \"lecture\", \"lab\" or \"seminar\"."@en ;
-          rdfs:isDefinedBy "caliper:"^^xsd:string ;
           rdfs:label "category"@en .
 
 


### PR DESCRIPTION
This PR adds/updates class and property comment descriptions based on the spec.  It also simplifies the ontology by removing all class and property equivalency annotations.  These can be added back as Caliper matures and if the working group is satisfied that equivalencies between Caliper concepts and other vocabulary concepts (e.g., FOAF, W3C Organization, Schema.org, SIOC, etc.) exist and are worth documenting.