### PR TITLE
Revise property axioms: Disjoint, Equivalencies, Functional, Irreflexive

### DIFF
--- a/caliper-jsonld.owl
+++ b/caliper-jsonld.owl
@@ -414,6 +414,9 @@
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Entity"
+  } ],
+  "http://www.w3.org/2002/07/owl#disjointWith" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Envelope",
@@ -506,6 +509,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
+  } ],
+  "http://www.w3.org/2002/07/owl#equivalentClass" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/OutcomeEvent"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Group",
@@ -1050,7 +1056,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/academicSession",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A human-readable identifier of the designated period in which a CourseOffering occurs."
@@ -1071,9 +1077,6 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "The action or predicate that binds the Event actor or subject to the Event object."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -1224,7 +1227,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/body",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A plain-text rendering of the body content of a Message."
@@ -1241,7 +1244,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/bookmarkNotes",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A plain text rendering of the note associated with a BookmarkAnnotation."
@@ -1258,7 +1261,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/category",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A plain-text descriptor that characterizes the purpose of the CourseSection such as \"lecture\", \"lab\" or \"seminar\"."
@@ -1275,7 +1278,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/comment",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Plain text feedback provided by the scorer of a Result."
@@ -1292,7 +1295,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/count",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "The total number of attempts inclusive of the current Attempt that have been registered by the learner against the assigned resource."
@@ -1433,7 +1436,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/dateCreated",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A date and time value expressed with millisecond precision that describes when an Entity was created."
@@ -1620,7 +1623,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/endedAtTime",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A date and time value expressed with millisecond precision that describes when the activity was completed or terminated."
@@ -1708,7 +1711,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/eventTime",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A date and time value expressed with millisecond precision that indicates when an Event occurred."
@@ -1725,7 +1728,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/extensions",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "An ordered collection of objects not defined by the Caliper Information Model."
@@ -1774,6 +1777,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/LtiSession"
+  } ],
+  "http://www.w3.org/2002/07/owl#propertyDisjointWith" : [ {
+    "@id" : "http://purl.imsglobal.org/caliper/session"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/generated",
@@ -1845,7 +1851,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/isPartOf",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty", "http://www.w3.org/2002/07/owl#IrreflexiveProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A related Entity that includes or incorporates the resource as a part of its whole."
@@ -1879,7 +1885,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/items",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "An ordered collection of resources that comprise the collection."
@@ -2111,7 +2117,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/navigatedFrom",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "The DigitalResource or SoftwareApplication that constitutes the referring context of a Navigation Event.  Deprecated."
@@ -2237,7 +2243,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/replyTo",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty", "http://www.w3.org/2002/07/owl#IrreflexiveProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A prior Message that represents the post to which a Message is directed in reply."
@@ -2353,7 +2359,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/sendTime",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Envelope send time."
@@ -2370,7 +2376,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/sensor",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "Sensor identifier."
@@ -2421,7 +2427,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/startedAtTime",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A date and time value expressed with millisecond precision that describes when the activity commenced."
@@ -2455,7 +2461,7 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/subOrganizationOf",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#FunctionalProperty", "http://www.w3.org/2002/07/owl#IrreflexiveProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "The parent Organization of an Organization."

--- a/caliper-rdfxml.owl
+++ b/caliper-rdfxml.owl
@@ -205,6 +205,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/extensions -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/extensions">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
@@ -225,6 +226,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/LtiSession"/>
+        <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/session"/>
         <rdfs:comment xml:lang="en">If an Event occurs within the context of an LTI tool launch, the federatedSession constitutes the tool consumer&apos;s LtiSession.</rdfs:comment>
         <rdfs:label xml:lang="en">federatedSession</rdfs:label>
     </owl:ObjectProperty>
@@ -259,6 +261,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/isPartOf">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
@@ -277,7 +280,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/items -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/items">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">An ordered collection of resources that comprise the collection.</rdfs:comment>
@@ -355,6 +357,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/navigatedFrom -->
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/navigatedFrom">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:comment xml:lang="en">The DigitalResource or SoftwareApplication that constitutes the referring context of a Navigation Event.  Deprecated.</rdfs:comment>
         <rdfs:label xml:lang="en">navigatedFrom</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -402,6 +405,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/replyTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:comment xml:lang="en">A prior Message that represents the post to which a Message is directed in reply.</rdfs:comment>
@@ -467,6 +471,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
 
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/subOrganizationOf">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:comment xml:lang="en">The parent Organization of an Organization.</rdfs:comment>
@@ -552,7 +557,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/academicSession -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/academicSession">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A human-readable identifier of the designated period in which a CourseOffering occurs.</rdfs:comment>
@@ -565,7 +569,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/action">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The action or predicate that binds the Event actor or subject to the Event object.</rdfs:comment>
         <rdfs:label xml:lang="en">action</rdfs:label>
@@ -576,7 +579,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/body -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/body">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain-text rendering of the body content of a Message.</rdfs:comment>
@@ -588,7 +590,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/bookmarkNotes -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/bookmarkNotes">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/BookmarkAnnotation"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain text rendering of the note associated with a BookmarkAnnotation.</rdfs:comment>
@@ -600,7 +601,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/category -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/category">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseSection"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain-text descriptor that characterizes the purpose of the CourseSection such as &quot;lecture&quot;, &quot;lab&quot; or &quot;seminar&quot;.</rdfs:comment>
@@ -612,7 +612,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/comment -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/comment">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Plain text feedback provided by the scorer of a Result.</rdfs:comment>
@@ -624,7 +623,6 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/count -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/count">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">The total number of attempts inclusive of the current Attempt that have been registered by the learner against the assigned resource.</rdfs:comment>
@@ -693,6 +691,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/dateCreated -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/dateCreated">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when an Entity was created.</rdfs:comment>
@@ -812,6 +811,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/endedAtTime -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/endedAtTime">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
@@ -831,6 +831,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/eventTime -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/eventTime">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that indicates when an Event occurred.</rdfs:comment>
@@ -1047,6 +1048,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/sendTime -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/sendTime">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Envelope"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">Envelope send time.</rdfs:comment>
@@ -1058,6 +1060,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/sensor -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/sensor">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Envelope"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Sensor identifier.</rdfs:comment>
@@ -1080,6 +1083,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/startedAtTime -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/startedAtTime">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
@@ -1389,6 +1393,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/Entity -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Entity">
+        <owl:disjointWith rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:comment xml:lang="en">A Caliper Entity is a generic type that represents objects or things that participate in learning-related activities. Entity is subtyped for enhanced type specificity in order to better describe people, groups, digital content, courses, assignments, assessments, forums, messages, software applications and other entities that constitute the &quot;stuff&quot; of a Caliper Event.  Utilize Entity only if no suitable subtype exists to represent the thing being described.</rdfs:comment>
         <rdfs:label xml:lang="en">Entity</rdfs:label>
     </owl:Class>
@@ -1456,6 +1461,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/GradeEvent -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/GradeEvent">
+        <owl:equivalentClass rdf:resource="http://purl.imsglobal.org/caliper/OutcomeEvent"/>
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:comment xml:lang="en">A Caliper GradeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication.</rdfs:comment>
         <rdfs:label xml:lang="en">GradeEvent</rdfs:label>

--- a/caliper-turtle.owl
+++ b/caliper-turtle.owl
@@ -137,7 +137,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/extensions
-:extensions rdf:type owl:ObjectProperty ;
+:extensions rdf:type owl:ObjectProperty ,
+                     owl:FunctionalProperty ;
             rdfs:domain [ rdf:type owl:Class ;
                           owl:unionOf ( :Entity
                                         :Event
@@ -152,6 +153,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            owl:FunctionalProperty ;
                   rdfs:domain :Event ;
                   rdfs:range :LtiSession ;
+                  owl:propertyDisjointWith :session ;
                   rdfs:comment "If an Event occurs within the context of an LTI tool launch, the federatedSession constitutes the tool consumer's LtiSession."@en ;
                   rdfs:label "federatedSession"@en .
 
@@ -176,7 +178,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/isPartOf
 :isPartOf rdf:type owl:ObjectProperty ,
-                   owl:FunctionalProperty ;
+                   owl:FunctionalProperty ,
+                   owl:IrreflexiveProperty ;
           rdfs:domain [ rdf:type owl:Class ;
                         owl:unionOf ( :Attempt
                                       :DigitalResource
@@ -188,8 +191,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/items
-:items rdf:type owl:ObjectProperty ,
-                owl:FunctionalProperty ;
+:items rdf:type owl:ObjectProperty ;
        rdfs:domain :DigitalResourceCollection ;
        rdfs:range :DigitalResource ;
        rdfs:comment "An ordered collection of resources that comprise the collection."@en ;
@@ -245,7 +247,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/navigatedFrom
-:navigatedFrom rdf:type owl:ObjectProperty ;
+:navigatedFrom rdf:type owl:ObjectProperty ,
+                        owl:FunctionalProperty ;
                rdfs:comment "The DigitalResource or SoftwareApplication that constitutes the referring context of a Navigation Event.  Deprecated."@en ;
                rdfs:label "navigatedFrom"@en ;
                owl:deprecated "true"^^xsd:boolean .
@@ -280,7 +283,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/replyTo
 :replyTo rdf:type owl:ObjectProperty ,
-                  owl:FunctionalProperty ;
+                  owl:FunctionalProperty ,
+                  owl:IrreflexiveProperty ;
          rdfs:domain :Message ;
          rdfs:range :Message ;
          rdfs:comment "A prior Message that represents the post to which a Message is directed in reply."@en ;
@@ -327,7 +331,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/subOrganizationOf
 :subOrganizationOf rdf:type owl:ObjectProperty ,
-                            owl:FunctionalProperty ;
+                            owl:FunctionalProperty ,
+                            owl:IrreflexiveProperty ;
                    rdfs:domain :Organization ;
                    rdfs:range :Organization ;
                    rdfs:comment "The parent Organization of an Organization."@en ;
@@ -384,8 +389,7 @@ xsd:duration rdf:type rdfs:Datatype .
 #################################################################
 
 ###  http://purl.imsglobal.org/caliper/academicSession
-:academicSession rdf:type owl:DatatypeProperty ,
-                          owl:FunctionalProperty ;
+:academicSession rdf:type owl:DatatypeProperty ;
                  rdfs:domain :CourseOffering ;
                  rdfs:range xsd:string ;
                  rdfs:comment "A human-readable identifier of the designated period in which a CourseOffering occurs."@en ;
@@ -395,15 +399,13 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/action
 :action rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
-        rdfs:domain :Event ;
         rdfs:range xsd:string ;
         rdfs:comment "The action or predicate that binds the Event actor or subject to the Event object."@en ;
         rdfs:label "action"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/body
-:body rdf:type owl:DatatypeProperty ,
-               owl:FunctionalProperty ;
+:body rdf:type owl:DatatypeProperty ;
       rdfs:domain :Message ;
       rdfs:range xsd:string ;
       rdfs:comment "A plain-text rendering of the body content of a Message."@en ;
@@ -411,8 +413,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/bookmarkNotes
-:bookmarkNotes rdf:type owl:DatatypeProperty ,
-                        owl:FunctionalProperty ;
+:bookmarkNotes rdf:type owl:DatatypeProperty ;
                rdfs:domain :BookmarkAnnotation ;
                rdfs:range xsd:string ;
                rdfs:comment "A plain text rendering of the note associated with a BookmarkAnnotation."@en ;
@@ -420,8 +421,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/category
-:category rdf:type owl:DatatypeProperty ,
-                   owl:FunctionalProperty ;
+:category rdf:type owl:DatatypeProperty ;
           rdfs:domain :CourseSection ;
           rdfs:range xsd:string ;
           rdfs:comment "A plain-text descriptor that characterizes the purpose of the CourseSection such as \"lecture\", \"lab\" or \"seminar\"."@en ;
@@ -429,8 +429,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/comment
-:comment rdf:type owl:DatatypeProperty ,
-                  owl:FunctionalProperty ;
+:comment rdf:type owl:DatatypeProperty ;
          rdfs:domain :Result ;
          rdfs:range xsd:string ;
          rdfs:comment "Plain text feedback provided by the scorer of a Result."@en ;
@@ -438,8 +437,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/count
-:count rdf:type owl:DatatypeProperty ,
-                owl:FunctionalProperty ;
+:count rdf:type owl:DatatypeProperty ;
        rdfs:domain :Attempt ;
        rdfs:range xsd:nonNegativeInteger ;
        rdfs:comment "The total number of attempts inclusive of the current Attempt that have been registered by the learner against the assigned resource."@en ;
@@ -489,7 +487,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/dateCreated
-:dateCreated rdf:type owl:DatatypeProperty ;
+:dateCreated rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
              rdfs:domain :Entity ;
              rdfs:range xsd:dateTime ;
              rdfs:comment "A date and time value expressed with millisecond precision that describes when an Entity was created."@en ;
@@ -575,7 +574,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/endedAtTime
-:endedAtTime rdf:type owl:DatatypeProperty ;
+:endedAtTime rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
              rdfs:domain [ rdf:type owl:Class ;
                            owl:unionOf ( :Attempt
                                          :Response
@@ -588,7 +588,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/eventTime
-:eventTime rdf:type owl:DatatypeProperty ;
+:eventTime rdf:type owl:DatatypeProperty ,
+                    owl:FunctionalProperty ;
            rdfs:domain :Event ;
            rdfs:range xsd:dateTime ;
            rdfs:comment "A date and time value expressed with millisecond precision that indicates when an Event occurred."@en ;
@@ -744,7 +745,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/sendTime
-:sendTime rdf:type owl:DatatypeProperty ;
+:sendTime rdf:type owl:DatatypeProperty ,
+                   owl:FunctionalProperty ;
           rdfs:domain :Envelope ;
           rdfs:range xsd:dateTime ;
           rdfs:comment "Envelope send time."@en ;
@@ -752,7 +754,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/sensor
-:sensor rdf:type owl:DatatypeProperty ;
+:sensor rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
         rdfs:domain :Envelope ;
         rdfs:range xsd:string ;
         rdfs:comment "Sensor identifier."@en ;
@@ -768,7 +771,8 @@ xsd:duration rdf:type rdfs:Datatype .
 
 
 ###  http://purl.imsglobal.org/caliper/startedAtTime
-:startedAtTime rdf:type owl:DatatypeProperty ;
+:startedAtTime rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
                rdfs:domain [ rdf:type owl:Class ;
                              owl:unionOf ( :Attempt
                                            :Response
@@ -981,6 +985,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/Entity
 :Entity rdf:type owl:Class ;
+        owl:disjointWith :Event ;
         rdfs:comment "A Caliper Entity is a generic type that represents objects or things that participate in learning-related activities. Entity is subtyped for enhanced type specificity in order to better describe people, groups, digital content, courses, assignments, assessments, forums, messages, software applications and other entities that constitute the \"stuff\" of a Caliper Event.  Utilize Entity only if no suitable subtype exists to represent the thing being described."@en ;
         rdfs:label "Entity"@en .
 
@@ -1027,6 +1032,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/GradeEvent
 :GradeEvent rdf:type owl:Class ;
+            owl:equivalentClass :OutcomeEvent ;
             rdfs:subClassOf :Event ;
             rdfs:comment "A Caliper GradeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication."@en ;
             rdfs:label "GradeEvent"@en .


### PR DESCRIPTION
This PR revises the following property axioms:

**Disjoint classes**
Event <> Entity

**Equivalencies**
GradeEvent = OutcomeEvent (deprecated)

**Functional object properties**
i.e., every Event can be linked by the property to at most one other Entity.

Event
   actor
   object
   edApp
   target
   generated
   referrer
   group
   membership
   session
   federateSession
   extensions

Annotation
  annotated
  annotator

Attempt
  assignee
  assignable

HighlightAnnotation
  selection

Membership
   member
   organization

Message
  replyTo

Organization
   subOrganizationOf

Response
   attempt

Result
   attempt
   scoredBy

Score
  scoredBy

Session
  user

**Functional data properties**
id
action
dateCreated
endedAtTime
eventTime
startedAtTime
sendTime
sensor (id)

**Irreflexive data properties**
i.e., No Entity can be related to itself via the property. A typical example is the following which simply states that nobody can be his own parent.

DigitalResource.isPartOf<Entity>
Message.replyTo<Message>
Organization.subOrganizationOf<Organization>
