### PR TITLE
CourseSection is a subtype of CourseOffering; academicSession data property Domain is CourseOffering; add missing Domain and Range to deprecated navigatedFrom object property

### DIFF
--- a/caliper-jsonld.owl
+++ b/caliper-jsonld.owl
@@ -360,7 +360,7 @@
     "@value" : "CourseSection"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/Organization"
+    "@id" : "http://purl.imsglobal.org/caliper/CourseOffering"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/DigitalResource",
@@ -1318,7 +1318,7 @@
     "@value" : "A human-readable identifier of the CourseOffering or CourseSection."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
-    "@id" : "http://purl.imsglobal.org/caliper/CourseSection"
+    "@id" : "http://purl.imsglobal.org/caliper/CourseOffering"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",

--- a/caliper-rdfxml.owl
+++ b/caliper-rdfxml.owl
@@ -636,7 +636,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/courseNumber -->
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/courseNumber">
-        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseSection"/>
+        <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A human-readable identifier of the CourseOffering or CourseSection.</rdfs:comment>
         <rdfs:label xml:lang="en">courseNumber</rdfs:label>
@@ -1355,7 +1355,7 @@ The Caliper Analytics® specification attempts to address the underlying interop
     <!-- http://purl.imsglobal.org/caliper/CourseSection -->
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/CourseSection">
-        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
+        <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:comment xml:lang="en">A Caliper CourseSection represents a specific instance of a CourseOffering occurring during a specific semester, term or period.</rdfs:comment>
         <rdfs:label xml:lang="en">CourseSection</rdfs:label>
     </owl:Class>

--- a/caliper-turtle.owl
+++ b/caliper-turtle.owl
@@ -448,7 +448,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/courseNumber
 :courseNumber rdf:type owl:DatatypeProperty ;
-              rdfs:domain :CourseSection ;
+              rdfs:domain :CourseOffering ;
               rdfs:range xsd:string ;
               rdfs:comment "A human-readable identifier of the CourseOffering or CourseSection."@en ;
               rdfs:label "courseNumber"@en .
@@ -959,7 +959,7 @@ xsd:duration rdf:type rdfs:Datatype .
 
 ###  http://purl.imsglobal.org/caliper/CourseSection
 :CourseSection rdf:type owl:Class ;
-               rdfs:subClassOf :Organization ;
+               rdfs:subClassOf :CourseOffering ;
                rdfs:comment "A Caliper CourseSection represents a specific instance of a CourseOffering occurring during a specific semester, term or period."@en ;
                rdfs:label "CourseSection"@en .
 


### PR DESCRIPTION
This PR resolves the following issues: #31 and #32.

