### PR TITLE
Refine ontology with additional class expressions and named individuals

### DIFF
--- a/caliper-jsonld.owl
+++ b/caliper-jsonld.owl
@@ -2741,13 +2741,27 @@
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Action",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ]
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Caliper includes a vocabulary of actions for describing learning interactions. Each action is based on the past-tense form of an English (en-US) verb. An action can also indicate a change in a particular characteristic of the object (e.g., resolution, size, speed, volume).  Each action is also linked to a brief definition (\"gloss\") derived in whole or in part from Princeton University's WordNet® project in order to eliminate ambiguity and aid natural language processing."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Action"
+  } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/Agent",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Agent is a generic type that represents an Entity that can initiate or perform an action.  Utilize Agent only if no suitable subtype exists to represent the actor being described."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2762,6 +2776,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Annotation is a generic type that represents a comment, explanation, highlight, mark, note, question or tag linked to a DigitalResource."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2780,6 +2797,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper AnnotationEvent models the annotating of digital content. The resulting Annotation is also described and is subtyped for greater type specificity."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2805,6 +2825,9 @@
     "@language" : "en",
     "@value" : "A Caliper Assessment represents an assessment instrument such as a test or quiz."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Assessment"
@@ -2822,6 +2845,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper AssessmentEvent models learner interactions with assessments instruments such as online tests or quizzes."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2845,6 +2871,9 @@
     "@language" : "en",
     "@value" : "A Caliper AssessmentItem represents a single test question."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "AssessmentItem"
@@ -2860,6 +2889,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper AssessmentItemEvent models a learner's interaction with an individual AssessmentItem."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2888,6 +2920,9 @@
     "@language" : "en",
     "@value" : "A Caliper AssignableDigitalResource is a generic type that represents digital content associated with a graded or ungraded assignment.  Utilize AssignableDigitalResource only if no suitable subtype exists to represent the resource being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "AssignableDigitalResource"
@@ -2901,6 +2936,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper AssignableEvent models activities associated with the assignment of digital content assigned to a learner for completion."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2926,6 +2964,9 @@
     "@language" : "en",
     "@value" : "A Caliper Attempt provides a count of the number of times an actor has interacted with an AssignableDigitalResource along with start time, end time and duration information. An Attempt is generated as the result of an action such as starting an Assessment."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Attempt"
@@ -2946,6 +2987,9 @@
     "@language" : "en",
     "@value" : "A Caliper AudioObject represents an audio or sound file."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "AudioObject"
@@ -2959,6 +3003,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper BookmarkAnnotation represents the act of marking a DigitalResource at a particular location."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -2974,6 +3021,9 @@
     "@language" : "en",
     "@value" : "A Caliper Chapter represents a major sub-division of a piece of digital content."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Chapter"
@@ -2987,6 +3037,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper CourseOffering represents the occurrence of a course or a type during a specified time period."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3005,6 +3058,9 @@
     "@language" : "en",
     "@value" : "A Caliper CourseSection represents a specific instance of a CourseOffering occurring during a specific semester, term or period."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "CourseSection"
@@ -3019,6 +3075,9 @@
     "@language" : "en",
     "@value" : "A Caliper DigitalResource is a generic type that represents digital content.  Utilize DigitalResource only if no suitable subtype exists to represent the resource being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "DigitalResource"
@@ -3032,6 +3091,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper DigitalResourceCollection represents an ordered collection of DigitalResource entities."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3049,6 +3111,9 @@
     "@language" : "en",
     "@value" : "A Caliper Document represents paginated textual content."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Document"
@@ -3063,6 +3128,9 @@
     "@language" : "en",
     "@value" : "A Caliper Entity is a generic type that represents objects or things that participate in learning-related activities. Entity is subtyped for enhanced type specificity in order to better describe people, groups, digital content, courses, assignments, assessments, forums, messages, software applications and other entities that constitute the \"stuff\" of a Caliper Event.  Utilize Entity only if no suitable subtype exists to represent the thing being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Entity"
@@ -3073,6 +3141,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Envelope is a container that is used to transmit one or more Caliper Events and/or Caliper Entity describes."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3085,6 +3156,9 @@
     "@language" : "en",
     "@value" : "A Caliper Event is a generic type that describes a relationship established between an actor and an object, formed as a result of a purposeful action undertaken by the actor in connection to the object at a particular moment in time."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Event"
@@ -3095,6 +3169,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper FillinBlankResponse represents a type of Response in which a respondent is asked to provide one or more words, expressions or short phrases that correctly completes a statement."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3109,6 +3186,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Forum represents a channel or virtual space in which group discussions take place.  A Forum typically comprises one or more threaded conversations to which members can subscribe, post messages and reply to other messages."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3125,6 +3205,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper ForumEvent models learners and others participating in online forum communities. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3146,6 +3229,9 @@
     "@language" : "en",
     "@value" : "A Caliper Frame represents a part, portion or segment of a DigitalResource."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Frame"
@@ -3159,6 +3245,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper GradeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3182,6 +3271,9 @@
     "@language" : "en",
     "@value" : "A Caliper Group represents an ad-hoc, informal or short-lived collection of people organized for some common educational or social purpose.  A Group can act as an Agent. It can be linked both to a parent Organization and to its members."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Group"
@@ -3195,6 +3287,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper HighlightAnnotation represents the act of marking a particular segment of a DigitalResource between two known coordinates."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3210,6 +3305,9 @@
     "@language" : "en",
     "@value" : "A Caliper ImageObject represents an image file."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "ImageObject"
@@ -3223,6 +3321,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper LearningObjective represents a brief statement of what a learner should know or be able to perform after completing a unit of instruction or a period of learning."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3252,6 +3353,9 @@
     "@language" : "en",
     "@value" : "A Caliper MediaEvent models interactions between learners and rich content such as audio, images and video."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "MediaEvent"
@@ -3274,6 +3378,9 @@
     "@language" : "en",
     "@value" : "A Caliper MediaLocation provides the current playback position in a MediaObject such as an AudioObject or VideoObject."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "MediaLocation"
@@ -3288,6 +3395,9 @@
     "@language" : "en",
     "@value" : "A Caliper MediaObject represents a generic piece of media content.  Utilize MediaObject only if no suitable subtype exists to represent the resource being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "MediaObject"
@@ -3301,6 +3411,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Membership describes the relationship between an Organization and a Person (i.e., a member) in terms of the roles assigned and current status."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3320,6 +3433,9 @@
     "@language" : "en",
     "@value" : "A Caliper Message is a digital form of written communication sent to a recipient. A series of messages may constitute a Thread if they share a common subject and are connected by a reply or by date relationships."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Message"
@@ -3335,6 +3451,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper MessageEvent describes a Person posting a Message or marking a post as either read or unread."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3356,6 +3475,9 @@
     "@language" : "en",
     "@value" : "A Caliper MultipleChoiceResponse represents a type of Response in which a respondent is asked to provide the best possible answer from a list of choices."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "MultipleChoiceResponse"
@@ -3370,6 +3492,9 @@
     "@language" : "en",
     "@value" : "A Caliper MultipleResponseResponse represents a form of response in which a respondent is asked to select more than one correct answer from a list of choices."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "MultipleResponseResponse"
@@ -3383,6 +3508,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper NavigationEvent models an actor traversing a network of digital resources."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3408,6 +3536,9 @@
     "@language" : "en",
     "@value" : "A Caliper Organization represents a formal collection of people organized for some common educational, social or administrative purpose. An Organization can act as an Agent. It can be linked both to a parent Organization and to its members."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Organization"
@@ -3424,6 +3555,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper OutcomeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication.  OutcomeEvent is DEPRECATED and will be removed in a future version of the specification. Use GradeEvent instead."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3451,6 +3585,9 @@
     "@language" : "en",
     "@value" : "A Caliper Page represents an item of paginated content."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Page"
@@ -3464,6 +3601,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Person represents a human being, alive or deceased, real or imaginary."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3482,6 +3622,9 @@
     "@language" : "en",
     "@value" : "A Caliper Reading represents paginated content. Reading is a DEPRECATED entity superseded by Document that will be removed in a future version of the specification. It SHOULD NOT be referenced."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Reading"
@@ -3499,6 +3642,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper ReadingEvent models an actor reading textural content.  ReadingEvent is DEPRECATED and will be removed in a future version of the specification.  It SHOULD NOT be referenced."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3526,6 +3672,9 @@
     "@language" : "en",
     "@value" : "A Caliper Response is a generic type that represents the selected option generated by a Person interacting with an AssessmentItem.  Utilize Response only if no suitable subtype exists to represent the response being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Response"
@@ -3539,6 +3688,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Result represents a grade applied to an assignment submission."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3568,6 +3720,9 @@
     "@language" : "en",
     "@value" : "A Caliper Score represents a grade.  The Score value is considered immutable."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Score"
@@ -3581,6 +3736,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper SelectTextResponse represents a type of Response that identifies text or a mapping from a presented paragraph or list."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3596,6 +3754,9 @@
     "@language" : "en",
     "@value" : "A Caliper Selector is a generic class that describes a fragment or segment of a resource.  Utilize Selector only if no suitable subtype exists to represent the selection being described."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "Selector"
@@ -3606,6 +3767,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Session represents a web application user session."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3622,6 +3786,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper SessionEvent models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3647,6 +3814,9 @@
     "@language" : "en",
     "@value" : "A Caliper SharedAnnotation represents the act of sharing a reference to a DigitalResource with other agents."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "SharedAnnotation"
@@ -3660,6 +3830,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper SoftwareApplication represents a computer program, application, module, platform or system."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3689,6 +3862,9 @@
     "@language" : "en",
     "@value" : "A Caliper TagAnnotation represents the act of tagging a DigitalResource with tags or labels."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "TagAnnotation"
@@ -3703,6 +3879,9 @@
     "@language" : "en",
     "@value" : "A Caliper TextPositionSelector represents a fragment or selection of textual content, the starting and ending positions of which are determined by the distance in characters from the initial character (position 0) of the enclosing full text."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "TextPositionSelector"
@@ -3716,6 +3895,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper Thread represents a series of one or more messages that share a common subject and are connected by a reply or by date relationships."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3734,6 +3916,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper ThreadEvent models an actor interacting with a Forum thread or topic."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3754,6 +3939,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper ToolUseEvent models a Person using a learning tool in a way that the tool's creators have determined is an indication of a learning interaction."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3777,6 +3965,9 @@
     "@language" : "en",
     "@value" : "A Caliper TrueFalseResponse represents a type of Response to an AssessmentItem in which only two possible options are provided (e.g., true/false, yes/no)."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "TrueFalseResponse"
@@ -3791,6 +3982,9 @@
     "@language" : "en",
     "@value" : "A Caliper VideoObject represents a visual recording stored in digital form."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "VideoObject"
@@ -3804,6 +3998,9 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A Caliper ViewEvent describes an actor's examination of digital content whenever the activity emphasizes thoughtful observation or study as opposed to the mere retrieval of a resource."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -3827,6 +4024,9 @@
     "@language" : "en",
     "@value" : "A Caliper WebPage represents a document containing markup that is suitable for display in a web browser."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "WebPage"
@@ -3844,6 +4044,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/CourseOffering"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "academicSession"
@@ -3860,6 +4063,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4822,6 +5028,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "actor"
@@ -4841,6 +5050,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4863,6 +5075,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Annotation"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "annotated"
@@ -4879,6 +5094,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Annotation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4897,6 +5115,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "assignable"
@@ -4913,6 +5134,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4931,6 +5155,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Message"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "attachments"
@@ -4947,6 +5174,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid1"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4965,6 +5195,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Message"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "body"
@@ -4981,6 +5214,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/BookmarkAnnotation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -4999,6 +5235,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/CourseSection"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "category"
@@ -5015,6 +5254,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5033,6 +5275,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Attempt"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "count"
@@ -5049,6 +5294,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/CourseOffering"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5067,6 +5315,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "creators"
@@ -5084,6 +5335,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/MediaLocation"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "currentTime"
@@ -5100,6 +5354,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5122,6 +5379,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "curvedTotalScore"
@@ -5143,6 +5403,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Envelope"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "data"
@@ -5160,6 +5423,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Envelope"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "dataVersion"
@@ -5176,6 +5442,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5197,6 +5466,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "dateModified"
@@ -5213,6 +5485,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5231,6 +5506,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "dateToActivate"
@@ -5247,6 +5525,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5265,6 +5546,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "dateToStartOn"
@@ -5281,6 +5565,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5299,6 +5586,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "description"
@@ -5315,6 +5605,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid14"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5333,6 +5626,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "edApp"
@@ -5349,6 +5645,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/TextPositionSelector"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5370,6 +5669,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid19"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "endedAtTime"
@@ -5390,6 +5692,9 @@
     "@language" : "en",
     "@value" : "A Caliper EpubChapter represents a major structural division of a piece of writing. EpubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "EpubChapter"
@@ -5408,6 +5713,9 @@
     "@language" : "en",
     "@value" : "A Caliper EpubPart represents a major structural division of a piece of writing, typically encapsulating a set of related chapters. EpubPart is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "EpubPart"
@@ -5424,6 +5732,9 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@value" : "A Caliper EpubSubChapter represents a major sub-division of an EpubChapter. EpubSubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5448,6 +5759,9 @@
     "@language" : "en",
     "@value" : "A Caliper EpubVolume represents a component of a collection. EpubVolume inherits all the properties and requirements defined for DigitalResource, its supertype. EpubVolume is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "EpubVolume"
@@ -5469,6 +5783,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "eventTime"
@@ -5486,6 +5803,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid8"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "extensions"
@@ -5499,6 +5819,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5521,6 +5844,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "federatedSession"
@@ -5537,6 +5863,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5555,6 +5884,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "group"
@@ -5571,6 +5903,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid23"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5589,6 +5924,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Frame"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "index"
@@ -5605,6 +5943,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5623,6 +5964,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AssessmentItem"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "isTimeDependent"
@@ -5639,6 +5983,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResourceCollection"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5657,6 +6004,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "keywords"
@@ -5673,6 +6023,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5691,6 +6044,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "maxAttempts"
@@ -5707,6 +6063,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5725,6 +6084,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid26"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "maxScore"
@@ -5741,6 +6103,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5759,6 +6124,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "mediaType"
@@ -5775,6 +6143,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Membership"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5793,6 +6164,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Organization"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "members"
@@ -5809,6 +6183,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5827,6 +6204,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/LtiSession"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "messageParameters"
@@ -5840,6 +6220,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5857,6 +6240,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Entity"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5877,6 +6263,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/NavigationEvent"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5899,6 +6288,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "normalScore"
@@ -5920,6 +6312,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "object"
@@ -5936,6 +6331,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/DigitalResource"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5955,6 +6353,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Membership"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "organization"
@@ -5971,6 +6372,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -5993,6 +6397,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "referrer"
@@ -6009,6 +6416,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Message"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6027,6 +6437,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "resultScore"
@@ -6043,6 +6456,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Membership"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6061,6 +6477,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Score"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "scoreGiven"
@@ -6077,6 +6496,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid11"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6095,6 +6517,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/HighlightAnnotation"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "selection"
@@ -6111,6 +6536,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/HighlightAnnotation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6129,6 +6557,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Envelope"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "sendTime"
@@ -6145,6 +6576,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Envelope"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6163,6 +6597,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "session"
@@ -6179,6 +6616,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/TextPositionSelector"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6197,6 +6637,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid29"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "startedAtTime"
@@ -6213,6 +6656,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Membership"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6231,6 +6677,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Organization"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "subOrganizationOf"
@@ -6247,6 +6696,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/TagAnnotation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6265,6 +6717,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Event"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "target"
@@ -6281,6 +6736,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Result"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6303,6 +6761,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid33"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "type"
@@ -6319,6 +6780,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/Session"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6337,6 +6801,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid36"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "value"
@@ -6353,6 +6820,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid39"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6371,6 +6841,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "_:genid43"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "version"
@@ -6388,6 +6861,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "volumeLevel"
@@ -6404,6 +6880,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -6425,6 +6904,9 @@
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/AudioObject"
   } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
+  } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "volumeMin"
@@ -6441,6 +6923,9 @@
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "http://purl.imsglobal.org/caliper/SharedAnnotation"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#isDefinedBy" : [ {
+    "@value" : "http://purl.imsglobal.org/caliper"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",

--- a/caliper-rdfxml.owl
+++ b/caliper-rdfxml.owl
@@ -109,6 +109,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Action"/>
         <rdfs:comment xml:lang="en">The action or predicate that binds the Event actor or subject to the Event object.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">action</rdfs:label>
     </owl:ObjectProperty>
     
@@ -121,6 +122,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Agent who initiated the Event, typically a Person, Organization or SoftwareApplication.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">actor</rdfs:label>
     </owl:ObjectProperty>
     
@@ -133,6 +135,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/LearningObjective"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/learningObjectives"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more LearningObjective entities that describe what a learner is expected to comprehend or accomplish after engaging with the resource.  Deprecated.  Use learningObjectives.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">alignedLearningObjective</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
@@ -146,6 +149,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">The DigitalResource that was annotated by the annotator.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">annotated</rdfs:label>
     </owl:ObjectProperty>
     
@@ -158,6 +162,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Person who created the Annotation.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">annotator</rdfs:label>
     </owl:ObjectProperty>
     
@@ -170,6 +175,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">The DigitalResource that constitutes the object of the assignment.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">assignable</rdfs:label>
     </owl:ObjectProperty>
     
@@ -182,6 +188,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Person who initiated the Attempt of an assigned DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">assignee</rdfs:label>
     </owl:ObjectProperty>
     
@@ -193,6 +200,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more DigitalResource entities attached to a Message.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">attachments</rdfs:label>
     </owl:ObjectProperty>
     
@@ -213,6 +221,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
         <rdfs:comment xml:lang="en">The associated Attempt.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">attempt</rdfs:label>
     </owl:ObjectProperty>
     
@@ -224,6 +233,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">An ordered collection of Agent entities, typically of type Person, that are responsible for bringing resource into being</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">creators</rdfs:label>
     </owl:ObjectProperty>
     
@@ -242,6 +252,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:range>
         <rdfs:comment xml:lang="en">Envelope data array.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">data</rdfs:label>
     </owl:ObjectProperty>
     
@@ -254,6 +265,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/SoftwareApplication"/>
         <rdfs:comment xml:lang="en">A SoftwareApplication that represents the application context within which an Event occurs.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">edApp</rdfs:label>
     </owl:ObjectProperty>
     
@@ -271,6 +283,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:domain>
         <rdfs:comment xml:lang="en">An ordered collection of objects not defined by the Caliper Information Model.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">extensions</rdfs:label>
     </owl:ObjectProperty>
     
@@ -283,6 +296,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/LtiSession"/>
         <rdfs:comment xml:lang="en">If an Event occurs within the context of an LTI tool launch, the federatedSession constitutes the tool consumer&apos;s LtiSession.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">federatedSession</rdfs:label>
     </owl:ObjectProperty>
     
@@ -295,6 +309,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">An Entity created or generated as a result of an interaction between an actor and an object.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">generated</rdfs:label>
     </owl:ObjectProperty>
     
@@ -307,6 +322,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:comment xml:lang="en">An Organization that represents the group or organizational context within which an Event occurs.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">group</rdfs:label>
     </owl:ObjectProperty>
     
@@ -319,6 +335,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A related Entity that includes or incorporates the resource as a part of its whole.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">isPartOf</rdfs:label>
     </owl:ObjectProperty>
     
@@ -330,6 +347,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResourceCollection"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">An ordered collection of resources that comprise the collection.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">items</rdfs:label>
     </owl:ObjectProperty>
     
@@ -341,6 +359,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/LearningObjective"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more LearningObjective entities that describe what a learner is expected to comprehend or accomplish after engaging with the resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">learningObjectives</rdfs:label>
     </owl:ObjectProperty>
     
@@ -353,6 +372,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Membership"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Person associated with a Membership.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">member</rdfs:label>
     </owl:ObjectProperty>
     
@@ -364,6 +384,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">An ordered collection of entities of type Agent that belong to a particular group.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">members</rdfs:label>
     </owl:ObjectProperty>
     
@@ -376,6 +397,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Membership"/>
         <rdfs:comment xml:lang="en">The relationship between the actor and the group in terms of roles assigned and current status.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">membership</rdfs:label>
     </owl:ObjectProperty>
     
@@ -386,6 +408,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:ObjectProperty rdf:about="http://purl.imsglobal.org/caliper/messageParameters">
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/LtiSession"/>
         <rdfs:comment xml:lang="en">A map of LTI-specified message parameters that provide Tool Consumer-related contextual information MAY be specified.  LTI message parameters of whatever type (i.e., required, recommended, optional, custom and extension) MAY be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">messageParameters</rdfs:label>
     </owl:ObjectProperty>
     
@@ -399,6 +422,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/referrer"/>
         <rdfs:comment xml:lang="en">The DigitalResource or SoftwareApplication that constitutes the referring context of a Navigation Event.  Deprecated.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">navigatedFrom</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
@@ -412,6 +436,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">An Entity that an Event actor interacts with as described by the Event action.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">object</rdfs:label>
     </owl:ObjectProperty>
     
@@ -424,6 +449,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Membership"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:comment xml:lang="en">The Organization associated with a Membership.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">organization</rdfs:label>
     </owl:ObjectProperty>
     
@@ -436,6 +462,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">An Entity that represents the referring context within which an Event occurs.  A SoftwareApplication or DigitalResource will typically constitute the referring context.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">referrer</rdfs:label>
     </owl:ObjectProperty>
     
@@ -449,6 +476,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:comment xml:lang="en">A prior Message that represents the post to which a Message is directed in reply.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">replyTo</rdfs:label>
     </owl:ObjectProperty>
     
@@ -460,6 +488,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Membership"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Role"/>
         <rdfs:comment xml:lang="en">An ordered collection of organizational roles assigned to a member.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">roles</rdfs:label>
     </owl:ObjectProperty>
     
@@ -479,6 +508,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Agent who scored or graded an Attempt.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">scoredBy</rdfs:label>
     </owl:ObjectProperty>
     
@@ -491,6 +521,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/HighlightAnnotation"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/TextPositionSelector"/>
         <rdfs:comment xml:lang="en">A Selector that describes a fragment or segment of a resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">selection</rdfs:label>
     </owl:ObjectProperty>
     
@@ -503,6 +534,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Session"/>
         <rdfs:comment xml:lang="en">The current user Session.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">session</rdfs:label>
     </owl:ObjectProperty>
     
@@ -515,6 +547,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Membership"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Status"/>
         <rdfs:comment xml:lang="en">The current standing of a member.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">status</rdfs:label>
     </owl:ObjectProperty>
     
@@ -528,6 +561,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:comment xml:lang="en">The parent Organization of an Organization.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">subOrganizationOf</rdfs:label>
     </owl:ObjectProperty>
     
@@ -540,6 +574,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">An Entity that represents a particular segment or location within an Event object.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">target</rdfs:label>
     </owl:ObjectProperty>
     
@@ -552,6 +587,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Session"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">The Person who initiated a Session.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">user</rdfs:label>
     </owl:ObjectProperty>
     
@@ -563,6 +599,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/SharedAnnotation"/>
         <rdfs:range rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more Agent entities, typically of type Person, with whom the annotated DigitalResource has been shared.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">withAgents</rdfs:label>
     </owl:ObjectProperty>
     
@@ -586,6 +623,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A human-readable identifier of the designated period in which a CourseOffering occurs.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">academicSession</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -598,6 +636,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Message"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain-text rendering of the body content of a Message.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">body</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -610,6 +649,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/BookmarkAnnotation"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain text rendering of the note associated with a BookmarkAnnotation.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">bookmarkNotes</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -622,6 +662,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseSection"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A plain-text descriptor that characterizes the purpose of the CourseSection such as &quot;lecture&quot;, &quot;lab&quot; or &quot;seminar&quot;.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">category</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -634,6 +675,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Plain text feedback provided by the scorer of a Result.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">comment</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -646,6 +688,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Attempt"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">The total number of attempts inclusive of the current Attempt that have been registered by the learner against the assigned resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -658,6 +701,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A human-readable identifier of the CourseOffering or CourseSection.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">courseNumber</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -670,6 +714,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/MediaLocation"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
         <rdfs:comment xml:lang="en">A time interval or duration that represents the current playback position measured from the beginning of a MediaObject.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">currentTime</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -682,6 +727,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">A scale factor to be used in adjusting the totalScore.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">curveFactor</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -695,6 +741,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The total score earned by the learner after applying a curveFactor to a method for computing a scaled score; e.g., adjusting the score equal to the sum of 100 - curvedFactor(100 - totalScore).</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">curvedTotalScore</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -708,6 +755,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Envelope"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Envelope data payload Caliper version.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dataVersion</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -721,6 +769,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/dateModified"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when an Entity was created.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateCreated</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -733,6 +782,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when an Entity was last changed or modified.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateModified</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -745,6 +795,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that provides the publication date of a resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">datePublished</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -757,6 +808,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when a resource was activated.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateToActivate</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -769,6 +821,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when a resource should be shown or made available.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateToShow</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -781,6 +834,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when the resource can be started.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateToStartOn</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -793,6 +847,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when the resource is to be submitted for evaluation.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">dateToSubmit</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -805,6 +860,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A brief, plain-text representation of the resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">description</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -826,6 +882,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#duration"/>
         <rdfs:comment xml:lang="en">A time interval that represents the total time required to complete an activity.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">duration</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -839,6 +896,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/start"/>
         <rdfs:comment xml:lang="en">The end position of a segment of text. The first character in the full text is position 0. The character that represents the end position is NOT included within the selected segment.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">end</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -860,6 +918,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/startedAtTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when the activity was completed or terminated.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">endedAtTime</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -872,6 +931,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Event"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that indicates when an Event occurred.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">eventTime</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -884,6 +944,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The number of extra credit points earned by the learner.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">extraCreditScore</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -904,6 +965,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The Event or Entity identifier.  For an Event, the id MUST be a UUID expressed as a URN using the form urn:uuid:&lt;UUID&gt; per RFC 4122.  For Entities a valid IRI MUST be specified. The IRI MUST be unique and persistent. The IRI SHOULD also be dereferenceable, i.e., capable of returning a representation of the resource.  An Entity MAY be provisioned with a URI employing the URN scheme in cases where a Linked Data friendly HTTP URI is either unavailable or inappropriate.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">id</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -916,6 +978,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Frame"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
         <rdfs:comment xml:lang="en">A non-negative integer that represents the position of the Frame.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">index</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -928,6 +991,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AssessmentItem"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">A boolean value indicating whether or not interacting with the item is time dependent.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">isTimeDependent</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -939,6 +1003,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more string values that represent tags or labels used to identify the resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">keywords</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -951,6 +1016,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">A non-negative integer indicating the number of permitted attempts.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">maxAttempts</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -963,6 +1029,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The maximum score permitted for a Result.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">maxResultScore</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -982,6 +1049,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">A non-negative integer indicating the maximum score permitted.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">maxScore</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -994,6 +1062,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">A non-negative integer indicating the number of permitted submissions.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">maxSubmits</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1006,6 +1075,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value drawn from the list of IANA approved media types and subtypes that identifies the file format of a resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">mediaType</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1018,6 +1088,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AudioObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
         <rdfs:comment xml:lang="en">An optional boolean value indicating whether or not the MediaObject has been muted .</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">muted</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1030,6 +1101,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value comprising a word or phrase by which the resource is known.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1042,6 +1114,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The score earned by the learner before adding the extraCreditScore, subtracting the penaltyScore or applying the curveFactor, if any.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">normalScore</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -1054,6 +1127,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A string value that designates the resource type.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">objectType</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -1067,6 +1141,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The number of points deducted from the normalScore due to an infraction such as submitting an Attempt after the due date.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">penaltyScore</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -1080,6 +1155,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The result score awarded to the learner.  A result score can be updated.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">resultScore</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1092,6 +1168,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Score"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">The score value.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">scoreGiven</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1104,6 +1181,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/HighlightAnnotation"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value representing a plain-text rendering of the selected segment of the annotated resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">selectionText</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1116,6 +1194,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Envelope"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">Envelope send time.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">sendTime</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1128,6 +1207,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Envelope"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">Sensor identifier.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">sensor</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1140,6 +1220,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/TextPositionSelector"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
         <rdfs:comment xml:lang="en">The starting position of a segment of text. The first character in the full text is position 0. The character that represents the start position is included within the selected segment.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">start</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1160,6 +1241,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
         <rdfs:comment xml:lang="en">A date and time value expressed with millisecond precision that describes when the activity commenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">startedAtTime</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1172,6 +1254,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/TagAnnotation"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more string values that represent labels or tags associated with the annotated DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">tags</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1184,6 +1267,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/Result"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">A score earned by the learner equal to the sum of normalScore + extraCreditScore - penaltyScore. This value does not take into account the effects of curving.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">totalScore</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
@@ -1204,6 +1288,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value corresponding to the Class name or label of an Event or Entity.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">type</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1223,6 +1308,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value that represents the options selected.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">value</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1242,6 +1328,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">An ordered collection of one or more selected options.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">values</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1261,6 +1348,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value that designates the current form or version of the resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">version</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1273,6 +1361,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AudioObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">The current volume level.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">volumeLevel</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1286,6 +1375,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <owl:propertyDisjointWith rdf:resource="http://purl.imsglobal.org/caliper/volumeMin"/>
         <rdfs:comment xml:lang="en">A string value indicating the maximum volume level permitted.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">volumeMax</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1298,6 +1388,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AudioObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment xml:lang="en">A string value indicating the minimum volume level permitted.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">volumeMin</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1316,7 +1407,11 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <!-- http://purl.imsglobal.org/caliper/Action -->
 
-    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Action"/>
+    <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Action">
+        <rdfs:comment xml:lang="en">Caliper includes a vocabulary of actions for describing learning interactions. Each action is based on the past-tense form of an English (en-US) verb. An action can also indicate a change in a particular characteristic of the object (e.g., resolution, size, speed, volume).  Each action is also linked to a brief definition (&quot;gloss&quot;) derived in whole or in part from Princeton University&apos;s WordNet® project in order to eliminate ambiguity and aid natural language processing.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Action</rdfs:label>
+    </owl:Class>
     
 
 
@@ -1325,6 +1420,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Agent">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper Agent is a generic type that represents an Entity that can initiate or perform an action.  Utilize Agent only if no suitable subtype exists to represent the actor being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Agent</rdfs:label>
     </owl:Class>
     
@@ -1363,6 +1459,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Annotation is a generic type that represents a comment, explanation, highlight, mark, note, question or tag linked to a DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Annotation</rdfs:label>
     </owl:Class>
     
@@ -1436,6 +1533,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper AnnotationEvent models the annotating of digital content. The resulting Annotation is also described and is subtyped for greater type specificity.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AnnotationEvent</rdfs:label>
     </owl:Class>
     
@@ -1461,6 +1559,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Assessment represents an assessment instrument such as a test or quiz.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Assessment</rdfs:label>
     </owl:Class>
     
@@ -1530,6 +1629,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper AssessmentEvent models learner interactions with assessments instruments such as online tests or quizzes.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AssessmentEvent</rdfs:label>
     </owl:Class>
     
@@ -1554,6 +1654,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper AssessmentItem represents a single test question.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AssessmentItem</rdfs:label>
     </owl:Class>
     
@@ -1626,6 +1727,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper AssessmentItemEvent models a learner&apos;s interaction with an individual AssessmentItem.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AssessmentItemEvent</rdfs:label>
     </owl:Class>
     
@@ -1637,6 +1739,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper AssignableDigitalResource is a generic type that represents digital content associated with a graded or ungraded assignment.  Utilize AssignableDigitalResource only if no suitable subtype exists to represent the resource being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AssignableDigitalResource</rdfs:label>
     </owl:Class>
     
@@ -1712,6 +1815,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper AssignableEvent models activities associated with the assignment of digital content assigned to a learner for completion.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AssignableEvent</rdfs:label>
     </owl:Class>
     
@@ -1756,6 +1860,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Attempt provides a count of the number of times an actor has interacted with an AssignableDigitalResource along with start time, end time and duration information. An Attempt is generated as the result of an action such as starting an Assessment.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Attempt</rdfs:label>
     </owl:Class>
     
@@ -1766,6 +1871,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/AudioObject">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/MediaObject"/>
         <rdfs:comment xml:lang="en">A Caliper AudioObject represents an audio or sound file.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">AudioObject</rdfs:label>
     </owl:Class>
     
@@ -1776,6 +1882,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/BookmarkAnnotation">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:comment xml:lang="en">A Caliper BookmarkAnnotation represents the act of marking a DigitalResource at a particular location.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">BookmarkAnnotation</rdfs:label>
     </owl:Class>
     
@@ -1786,6 +1893,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Chapter">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper Chapter represents a major sub-division of a piece of digital content.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Chapter</rdfs:label>
     </owl:Class>
     
@@ -1797,6 +1905,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <owl:disjointWith rdf:resource="http://purl.imsglobal.org/caliper/Group"/>
         <rdfs:comment xml:lang="en">A Caliper CourseOffering represents the occurrence of a course or a type during a specified time period.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">CourseOffering</rdfs:label>
     </owl:Class>
     
@@ -1807,6 +1916,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/CourseSection">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/CourseOffering"/>
         <rdfs:comment xml:lang="en">A Caliper CourseSection represents a specific instance of a CourseOffering occurring during a specific semester, term or period.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">CourseSection</rdfs:label>
     </owl:Class>
     
@@ -1817,6 +1927,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/DigitalResource">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper DigitalResource is a generic type that represents digital content.  Utilize DigitalResource only if no suitable subtype exists to represent the resource being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">DigitalResource</rdfs:label>
     </owl:Class>
     
@@ -1841,6 +1952,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper DigitalResourceCollection represents an ordered collection of DigitalResource entities.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">DigitalResourceCollection</rdfs:label>
     </owl:Class>
     
@@ -1851,6 +1963,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Document">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper Document represents paginated textual content.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Document</rdfs:label>
     </owl:Class>
     
@@ -1860,6 +1973,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Entity">
         <rdfs:comment xml:lang="en">A Caliper Entity is a generic type that represents objects or things that participate in learning-related activities. Entity is subtyped for enhanced type specificity in order to better describe people, groups, digital content, courses, assignments, assessments, forums, messages, software applications and other entities that constitute the &quot;stuff&quot; of a Caliper Event.  Utilize Entity only if no suitable subtype exists to represent the thing being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Entity</rdfs:label>
     </owl:Class>
     
@@ -1869,6 +1983,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Envelope">
         <rdfs:comment xml:lang="en">A Caliper Envelope is a container that is used to transmit one or more Caliper Events and/or Caliper Entity describes.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Envelope</rdfs:label>
     </owl:Class>
     
@@ -1878,6 +1993,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Event">
         <rdfs:comment xml:lang="en">A Caliper Event is a generic type that describes a relationship established between an actor and an object, formed as a result of a purposeful action undertaken by the actor in connection to the object at a particular moment in time.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Event</rdfs:label>
     </owl:Class>
     
@@ -1888,6 +2004,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/FillinBlankResponse">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
         <rdfs:comment xml:lang="en">A Caliper FillinBlankResponse represents a type of Response in which a respondent is asked to provide one or more words, expressions or short phrases that correctly completes a statement.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">FillinBlankResponse</rdfs:label>
     </owl:Class>
     
@@ -1912,6 +2029,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Forum represents a channel or virtual space in which group discussions take place.  A Forum typically comprises one or more threaded conversations to which members can subscribe, post messages and reply to other messages.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Forum</rdfs:label>
     </owl:Class>
     
@@ -1971,6 +2089,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper ForumEvent models learners and others participating in online forum communities. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ForumEvent</rdfs:label>
     </owl:Class>
     
@@ -1981,6 +2100,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Frame">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper Frame represents a part, portion or segment of a DigitalResource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Frame</rdfs:label>
     </owl:Class>
     
@@ -2046,6 +2166,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper GradeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">GradeEvent</rdfs:label>
     </owl:Class>
     
@@ -2056,6 +2177,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Group">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Organization"/>
         <rdfs:comment xml:lang="en">A Caliper Group represents an ad-hoc, informal or short-lived collection of people organized for some common educational or social purpose.  A Group can act as an Agent. It can be linked both to a parent Organization and to its members.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Group</rdfs:label>
     </owl:Class>
     
@@ -2066,6 +2188,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/HighlightAnnotation">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:comment xml:lang="en">A Caliper HighlightAnnotation represents the act of marking a particular segment of a DigitalResource between two known coordinates.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">HighlightAnnotation</rdfs:label>
     </owl:Class>
     
@@ -2076,6 +2199,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/ImageObject">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/MediaObject"/>
         <rdfs:comment xml:lang="en">A Caliper ImageObject represents an image file.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ImageObject</rdfs:label>
     </owl:Class>
     
@@ -2086,6 +2210,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/LearningObjective">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper LearningObjective represents a brief statement of what a learner should know or be able to perform after completing a unit of instruction or a period of learning.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">LearningObjective</rdfs:label>
     </owl:Class>
     
@@ -2178,6 +2303,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper MediaEvent models interactions between learners and rich content such as audio, images and video.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MediaEvent</rdfs:label>
     </owl:Class>
     
@@ -2188,6 +2314,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MediaLocation">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper MediaLocation provides the current playback position in a MediaObject such as an AudioObject or VideoObject.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MediaLocation</rdfs:label>
     </owl:Class>
     
@@ -2198,6 +2325,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MediaObject">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper MediaObject represents a generic piece of media content.  Utilize MediaObject only if no suitable subtype exists to represent the resource being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MediaObject</rdfs:label>
     </owl:Class>
     
@@ -2236,6 +2364,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Membership describes the relationship between an Organization and a Person (i.e., a member) in terms of the roles assigned and current status.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Membership</rdfs:label>
     </owl:Class>
     
@@ -2260,6 +2389,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Message is a digital form of written communication sent to a recipient. A series of messages may constitute a Thread if they share a common subject and are connected by a reply or by date relationships.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Message</rdfs:label>
     </owl:Class>
     
@@ -2320,6 +2450,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper MessageEvent describes a Person posting a Message or marking a post as either read or unread.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MessageEvent</rdfs:label>
     </owl:Class>
     
@@ -2330,6 +2461,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MultipleChoiceResponse">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
         <rdfs:comment xml:lang="en">A Caliper MultipleChoiceResponse represents a type of Response in which a respondent is asked to provide the best possible answer from a list of choices.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MultipleChoiceResponse</rdfs:label>
     </owl:Class>
     
@@ -2340,6 +2472,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/MultipleResponseResponse">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
         <rdfs:comment xml:lang="en">A Caliper MultipleResponseResponse represents a form of response in which a respondent is asked to select more than one correct answer from a list of choices.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">MultipleResponseResponse</rdfs:label>
     </owl:Class>
     
@@ -2426,6 +2559,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper NavigationEvent models an actor traversing a network of digital resources.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">NavigationEvent</rdfs:label>
     </owl:Class>
     
@@ -2436,6 +2570,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Organization">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">A Caliper Organization represents a formal collection of people organized for some common educational, social or administrative purpose. An Organization can act as an Agent. It can be linked both to a parent Organization and to its members.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Organization</rdfs:label>
     </owl:Class>
     
@@ -2510,6 +2645,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         </rdfs:subClassOf>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/GradeEvent"/>
         <rdfs:comment xml:lang="en">A Caliper OutcomeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication.  OutcomeEvent is DEPRECATED and will be removed in a future version of the specification. Use GradeEvent instead.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">OutcomeEvent</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -2521,6 +2657,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Page">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper Page represents an item of paginated content.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Page</rdfs:label>
     </owl:Class>
     
@@ -2531,6 +2668,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Person">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">A Caliper Person represents a human being, alive or deceased, real or imaginary.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Person</rdfs:label>
     </owl:Class>
     
@@ -2542,6 +2680,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/Document"/>
         <rdfs:comment xml:lang="en">A Caliper Reading represents paginated content. Reading is a DEPRECATED entity superseded by Document that will be removed in a future version of the specification. It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Reading</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -2609,6 +2748,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper ReadingEvent models an actor reading textural content.  ReadingEvent is DEPRECATED and will be removed in a future version of the specification.  It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ReadingEvent</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -2620,6 +2760,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Response">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper Response is a generic type that represents the selected option generated by a Person interacting with an AssessmentItem.  Utilize Response only if no suitable subtype exists to represent the response being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Response</rdfs:label>
     </owl:Class>
     
@@ -2630,6 +2771,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Result">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper Result represents a grade applied to an assignment submission.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Result</rdfs:label>
     </owl:Class>
     
@@ -2650,6 +2792,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Score">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Entity"/>
         <rdfs:comment xml:lang="en">A Caliper Score represents a grade.  The Score value is considered immutable.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Score</rdfs:label>
     </owl:Class>
     
@@ -2660,6 +2803,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SelectTextResponse">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
         <rdfs:comment xml:lang="en">A Caliper SelectTextResponse represents a type of Response that identifies text or a mapping from a presented paragraph or list.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">SelectTextResponse</rdfs:label>
     </owl:Class>
     
@@ -2669,6 +2813,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/Selector">
         <rdfs:comment xml:lang="en">A Caliper Selector is a generic class that describes a fragment or segment of a resource.  Utilize Selector only if no suitable subtype exists to represent the selection being described.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Selector</rdfs:label>
     </owl:Class>
     
@@ -2693,6 +2838,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Session represents a web application user session.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Session</rdfs:label>
     </owl:Class>
     
@@ -2794,6 +2940,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper SessionEvent models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">SessionEvent</rdfs:label>
     </owl:Class>
     
@@ -2804,6 +2951,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SharedAnnotation">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:comment xml:lang="en">A Caliper SharedAnnotation represents the act of sharing a reference to a DigitalResource with other agents.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">SharedAnnotation</rdfs:label>
     </owl:Class>
     
@@ -2814,6 +2962,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/SoftwareApplication">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Agent"/>
         <rdfs:comment xml:lang="en">A Caliper SoftwareApplication represents a computer program, application, module, platform or system.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">SoftwareApplication</rdfs:label>
     </owl:Class>
     
@@ -2834,6 +2983,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/TagAnnotation">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Annotation"/>
         <rdfs:comment xml:lang="en">A Caliper TagAnnotation represents the act of tagging a DigitalResource with tags or labels.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">TagAnnotation</rdfs:label>
     </owl:Class>
     
@@ -2844,6 +2994,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/TextPositionSelector">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Selector"/>
         <rdfs:comment xml:lang="en">A Caliper TextPositionSelector represents a fragment or selection of textual content, the starting and ending positions of which are determined by the distance in characters from the initial character (position 0) of the enclosing full text.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">TextPositionSelector</rdfs:label>
     </owl:Class>
     
@@ -2882,6 +3033,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper Thread represents a series of one or more messages that share a common subject and are connected by a reply or by date relationships.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">Thread</rdfs:label>
     </owl:Class>
     
@@ -2941,6 +3093,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper ThreadEvent models an actor interacting with a Forum thread or topic.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ThreadEvent</rdfs:label>
     </owl:Class>
     
@@ -2999,6 +3152,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper ToolUseEvent models a Person using a learning tool in a way that the tool&apos;s creators have determined is an indication of a learning interaction.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ToolUseEvent</rdfs:label>
     </owl:Class>
     
@@ -3009,6 +3163,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/TrueFalseResponse">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/Response"/>
         <rdfs:comment xml:lang="en">A Caliper TrueFalseResponse represents a type of Response to an AssessmentItem in which only two possible options are provided (e.g., true/false, yes/no).</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">TrueFalseResponse</rdfs:label>
     </owl:Class>
     
@@ -3019,6 +3174,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/VideoObject">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/MediaObject"/>
         <rdfs:comment xml:lang="en">A Caliper VideoObject represents a visual recording stored in digital form.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">VideoObject</rdfs:label>
     </owl:Class>
     
@@ -3077,6 +3233,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">A Caliper ViewEvent describes an actor&apos;s examination of digital content whenever the activity emphasizes thoughtful observation or study as opposed to the mere retrieval of a resource.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">ViewEvent</rdfs:label>
     </owl:Class>
     
@@ -3087,6 +3244,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/WebPage">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper WebPage represents a document containing markup that is suitable for display in a web browser.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">WebPage</rdfs:label>
     </owl:Class>
     
@@ -3098,6 +3256,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/Chapter"/>
         <rdfs:comment xml:lang="en">A Caliper EpubChapter represents a major structural division of a piece of writing. EpubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">EpubChapter</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -3109,6 +3268,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:Class rdf:about="http://purl.imsglobal.org/caliper/epubPart">
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <rdfs:comment xml:lang="en">A Caliper EpubPart represents a major structural division of a piece of writing, typically encapsulating a set of related chapters. EpubPart is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">EpubPart</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -3134,6 +3294,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
             </owl:Class>
         </rdfs:subClassOf>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A Caliper EpubSubChapter represents a major sub-division of an EpubChapter. EpubSubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">EpubSubChapter</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -3146,6 +3307,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
         <rdfs:subClassOf rdf:resource="http://purl.imsglobal.org/caliper/DigitalResource"/>
         <terms:isReplacedBy rdf:resource="http://purl.imsglobal.org/caliper/Document"/>
         <rdfs:comment xml:lang="en">A Caliper EpubVolume represents a component of a collection. EpubVolume inherits all the properties and requirements defined for DigitalResource, its supertype. EpubVolume is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced.</rdfs:comment>
+        <rdfs:isDefinedBy>http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">EpubVolume</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>

--- a/caliper-turtle.owl
+++ b/caliper-turtle.owl
@@ -71,6 +71,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Event ;
         rdfs:range :Action ;
         rdfs:comment "The action or predicate that binds the Event actor or subject to the Event object."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "action"@en .
 
 
@@ -80,6 +81,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Event ;
        rdfs:range :Agent ;
        rdfs:comment "The Agent who initiated the Event, typically a Person, Organization or SoftwareApplication."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "actor"@en .
 
 
@@ -89,6 +91,7 @@ xsd:duration rdf:type rdfs:Datatype .
                           rdfs:range :LearningObjective ;
                           <http://purl.org/dc/terms/isReplacedBy> :learningObjectives ;
                           rdfs:comment "An ordered collection of one or more LearningObjective entities that describe what a learner is expected to comprehend or accomplish after engaging with the resource.  Deprecated.  Use learningObjectives."@en ;
+                          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                           rdfs:label "alignedLearningObjective"@en ;
                           owl:deprecated "true"^^xsd:boolean .
 
@@ -99,6 +102,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :Annotation ;
            rdfs:range :DigitalResource ;
            rdfs:comment "The DigitalResource that was annotated by the annotator."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "annotated"@en .
 
 
@@ -108,6 +112,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :Annotation ;
            rdfs:range :Agent ;
            rdfs:comment "The Person who created the Annotation."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "annotator"@en .
 
 
@@ -117,6 +122,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :Attempt ;
             rdfs:range :DigitalResource ;
             rdfs:comment "The DigitalResource that constitutes the object of the assignment."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "assignable"@en .
 
 
@@ -126,6 +132,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :Attempt ;
           rdfs:range :Agent ;
           rdfs:comment "The Person who initiated the Attempt of an assigned DigitalResource."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "assignee"@en .
 
 
@@ -134,6 +141,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Message ;
              rdfs:range :DigitalResource ;
              rdfs:comment "An ordered collection of one or more DigitalResource entities attached to a Message."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "attachments"@en .
 
 
@@ -148,6 +156,7 @@ xsd:duration rdf:type rdfs:Datatype .
                      ] ;
          rdfs:range :Attempt ;
          rdfs:comment "The associated Attempt."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "attempt"@en .
 
 
@@ -156,6 +165,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :DigitalResource ;
           rdfs:range :Agent ;
           rdfs:comment "An ordered collection of Agent entities, typically of type Person, that are responsible for bringing resource into being"@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "creators"@en .
 
 
@@ -168,6 +178,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                )
                  ] ;
       rdfs:comment "Envelope data array."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "data"@en .
 
 
@@ -177,6 +188,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Event ;
        rdfs:range :SoftwareApplication ;
        rdfs:comment "A SoftwareApplication that represents the application context within which an Event occurs."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "edApp"@en .
 
 
@@ -188,6 +200,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                       )
                         ] ;
             rdfs:comment "An ordered collection of objects not defined by the Caliper Information Model."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "extensions"@en .
 
 
@@ -197,6 +210,7 @@ xsd:duration rdf:type rdfs:Datatype .
                   rdfs:domain :Event ;
                   rdfs:range :LtiSession ;
                   rdfs:comment "If an Event occurs within the context of an LTI tool launch, the federatedSession constitutes the tool consumer's LtiSession."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                   rdfs:label "federatedSession"@en .
 
 
@@ -206,6 +220,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :Event ;
            rdfs:range :Entity ;
            rdfs:comment "An Entity created or generated as a result of an interaction between an actor and an object."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "generated"@en .
 
 
@@ -215,6 +230,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Event ;
        rdfs:range :Organization ;
        rdfs:comment "An Organization that represents the group or organizational context within which an Event occurs."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "group"@en .
 
 
@@ -224,6 +240,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :Entity ;
           rdfs:range :Entity ;
           rdfs:comment "A related Entity that includes or incorporates the resource as a part of its whole."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "isPartOf"@en .
 
 
@@ -232,6 +249,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :DigitalResourceCollection ;
        rdfs:range :Entity ;
        rdfs:comment "An ordered collection of resources that comprise the collection."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "items"@en .
 
 
@@ -240,6 +258,7 @@ xsd:duration rdf:type rdfs:Datatype .
                     rdfs:domain :DigitalResource ;
                     rdfs:range :LearningObjective ;
                     rdfs:comment "An ordered collection of one or more LearningObjective entities that describe what a learner is expected to comprehend or accomplish after engaging with the resource."@en ;
+                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                     rdfs:label "learningObjectives"@en .
 
 
@@ -249,6 +268,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Membership ;
         rdfs:range :Agent ;
         rdfs:comment "The Person associated with a Membership."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "member"@en .
 
 
@@ -257,6 +277,7 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:domain :Organization ;
          rdfs:range :Agent ;
          rdfs:comment "An ordered collection of entities of type Agent that belong to a particular group."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "members"@en .
 
 
@@ -266,6 +287,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :Event ;
             rdfs:range :Membership ;
             rdfs:comment "The relationship between the actor and the group in terms of roles assigned and current status."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "membership"@en .
 
 
@@ -273,6 +295,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :messageParameters rdf:type owl:ObjectProperty ;
                    rdfs:domain :LtiSession ;
                    rdfs:comment "A map of LTI-specified message parameters that provide Tool Consumer-related contextual information MAY be specified.  LTI message parameters of whatever type (i.e., required, recommended, optional, custom and extension) MAY be referenced."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                    rdfs:label "messageParameters"@en .
 
 
@@ -283,6 +306,7 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:range :Entity ;
                <http://purl.org/dc/terms/isReplacedBy> :referrer ;
                rdfs:comment "The DigitalResource or SoftwareApplication that constitutes the referring context of a Navigation Event.  Deprecated."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "navigatedFrom"@en ;
                owl:deprecated "true"^^xsd:boolean .
 
@@ -293,6 +317,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Event ;
         rdfs:range :Entity ;
         rdfs:comment "An Entity that an Event actor interacts with as described by the Event action."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "object"@en .
 
 
@@ -302,6 +327,7 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:domain :Membership ;
               rdfs:range :Organization ;
               rdfs:comment "The Organization associated with a Membership."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "organization"@en .
 
 
@@ -311,6 +337,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :Event ;
           rdfs:range :Entity ;
           rdfs:comment "An Entity that represents the referring context within which an Event occurs.  A SoftwareApplication or DigitalResource will typically constitute the referring context."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "referrer"@en .
 
 
@@ -321,6 +348,7 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:domain :Message ;
          rdfs:range :Message ;
          rdfs:comment "A prior Message that represents the post to which a Message is directed in reply."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "replyTo"@en .
 
 
@@ -329,6 +357,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Membership ;
        rdfs:range :Role ;
        rdfs:comment "An ordered collection of organizational roles assigned to a member."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "roles"@en .
 
 
@@ -342,6 +371,7 @@ xsd:duration rdf:type rdfs:Datatype .
                       ] ;
           rdfs:range :Agent ;
           rdfs:comment "The Agent who scored or graded an Attempt."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "scoredBy"@en .
 
 
@@ -351,6 +381,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :HighlightAnnotation ;
            rdfs:range :TextPositionSelector ;
            rdfs:comment "A Selector that describes a fragment or segment of a resource."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "selection"@en .
 
 
@@ -360,6 +391,7 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:domain :Event ;
          rdfs:range :Session ;
          rdfs:comment "The current user Session."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "session"@en .
 
 
@@ -369,6 +401,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Membership ;
         rdfs:range :Status ;
         rdfs:comment "The current standing of a member."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "status"@en .
 
 
@@ -379,6 +412,7 @@ xsd:duration rdf:type rdfs:Datatype .
                    rdfs:domain :Organization ;
                    rdfs:range :Organization ;
                    rdfs:comment "The parent Organization of an Organization."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                    rdfs:label "subOrganizationOf"@en .
 
 
@@ -388,6 +422,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Event ;
         rdfs:range :Entity ;
         rdfs:comment "An Entity that represents a particular segment or location within an Event object."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "target"@en .
 
 
@@ -397,6 +432,7 @@ xsd:duration rdf:type rdfs:Datatype .
       rdfs:domain :Session ;
       rdfs:range :Agent ;
       rdfs:comment "The Person who initiated a Session."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "user"@en .
 
 
@@ -405,6 +441,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :SharedAnnotation ;
             rdfs:range :Agent ;
             rdfs:comment "An ordered collection of one or more Agent entities, typically of type Person, with whom the annotated DigitalResource has been shared."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "withAgents"@en .
 
 
@@ -418,6 +455,7 @@ xsd:duration rdf:type rdfs:Datatype .
                  rdfs:domain :CourseOffering ;
                  rdfs:range xsd:string ;
                  rdfs:comment "A human-readable identifier of the designated period in which a CourseOffering occurs."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "academicSession"@en .
 
 
@@ -427,6 +465,7 @@ xsd:duration rdf:type rdfs:Datatype .
       rdfs:domain :Message ;
       rdfs:range xsd:string ;
       rdfs:comment "A plain-text rendering of the body content of a Message."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "body"@en .
 
 
@@ -436,6 +475,7 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:domain :BookmarkAnnotation ;
                rdfs:range xsd:string ;
                rdfs:comment "A plain text rendering of the note associated with a BookmarkAnnotation."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "bookmarkNotes"@en .
 
 
@@ -445,6 +485,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :CourseSection ;
           rdfs:range xsd:string ;
           rdfs:comment "A plain-text descriptor that characterizes the purpose of the CourseSection such as \"lecture\", \"lab\" or \"seminar\"."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "category"@en .
 
 
@@ -454,6 +495,7 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:domain :Result ;
          rdfs:range xsd:string ;
          rdfs:comment "Plain text feedback provided by the scorer of a Result."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "comment"@en .
 
 
@@ -463,6 +505,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Attempt ;
        rdfs:range xsd:nonNegativeInteger ;
        rdfs:comment "The total number of attempts inclusive of the current Attempt that have been registered by the learner against the assigned resource."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "count"@en .
 
 
@@ -472,6 +515,7 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:domain :CourseOffering ;
               rdfs:range xsd:string ;
               rdfs:comment "A human-readable identifier of the CourseOffering or CourseSection."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "courseNumber"@en .
 
 
@@ -481,6 +525,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :MediaLocation ;
              rdfs:range xsd:duration ;
              rdfs:comment "A time interval or duration that represents the current playback position measured from the beginning of a MediaObject."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "currentTime"@en .
 
 
@@ -490,6 +535,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Result ;
              rdfs:range xsd:decimal ;
              rdfs:comment "A scale factor to be used in adjusting the totalScore."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "curveFactor"@en ;
              owl:deprecated "true"^^xsd:boolean .
 
@@ -500,6 +546,7 @@ xsd:duration rdf:type rdfs:Datatype .
                   rdfs:domain :Result ;
                   rdfs:range xsd:decimal ;
                   rdfs:comment "The total score earned by the learner after applying a curveFactor to a method for computing a scaled score; e.g., adjusting the score equal to the sum of 100 - curvedFactor(100 - totalScore)."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                   rdfs:label "curvedTotalScore"@en ;
                   owl:deprecated "true"^^xsd:boolean .
 
@@ -510,6 +557,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Envelope ;
              rdfs:range xsd:string ;
              rdfs:comment "Envelope data payload Caliper version."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "dataVersion"@en .
 
 
@@ -520,6 +568,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:range xsd:dateTime ;
              owl:propertyDisjointWith :dateModified ;
              rdfs:comment "A date and time value expressed with millisecond precision that describes when an Entity was created."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "dateCreated"@en .
 
 
@@ -529,6 +578,7 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:domain :Entity ;
               rdfs:range xsd:dateTime ;
               rdfs:comment "A date and time value expressed with millisecond precision that describes when an Entity was last changed or modified."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "dateModified"@en .
 
 
@@ -538,6 +588,7 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:domain :DigitalResource ;
                rdfs:range xsd:dateTime ;
                rdfs:comment "A date and time value expressed with millisecond precision that provides the publication date of a resource."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "datePublished"@en .
 
 
@@ -547,6 +598,7 @@ xsd:duration rdf:type rdfs:Datatype .
                 rdfs:domain :DigitalResource ;
                 rdfs:range xsd:dateTime ;
                 rdfs:comment "A date and time value expressed with millisecond precision that describes when a resource was activated."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                 rdfs:label "dateToActivate"@en .
 
 
@@ -556,6 +608,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :DigitalResource ;
             rdfs:range xsd:dateTime ;
             rdfs:comment "A date and time value expressed with millisecond precision that describes when a resource should be shown or made available."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "dateToShow"@en .
 
 
@@ -565,6 +618,7 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:domain :DigitalResource ;
                rdfs:range xsd:dateTime ;
                rdfs:comment "A date and time value expressed with millisecond precision that describes when the resource can be started."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "dateToStartOn"@en .
 
 
@@ -574,6 +628,7 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:domain :DigitalResource ;
               rdfs:range xsd:dateTime ;
               rdfs:comment "A date and time value expressed with millisecond precision that describes when the resource is to be submitted for evaluation."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "dateToSubmit"@en .
 
 
@@ -583,6 +638,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Entity ;
              rdfs:range xsd:string ;
              rdfs:comment "A brief, plain-text representation of the resource."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "description"@en .
 
 
@@ -598,6 +654,7 @@ xsd:duration rdf:type rdfs:Datatype .
                       ] ;
           rdfs:range xsd:duration ;
           rdfs:comment "A time interval that represents the total time required to complete an activity."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "duration"@en .
 
 
@@ -608,6 +665,7 @@ xsd:duration rdf:type rdfs:Datatype .
      rdfs:range xsd:nonNegativeInteger ;
      owl:propertyDisjointWith :start ;
      rdfs:comment "The end position of a segment of text. The first character in the full text is position 0. The character that represents the end position is NOT included within the selected segment."@en ;
+     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
      rdfs:label "end"@en .
 
 
@@ -623,6 +681,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:range xsd:dateTime ;
              owl:propertyDisjointWith :startedAtTime ;
              rdfs:comment "A date and time value expressed with millisecond precision that describes when the activity was completed or terminated."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "endedAtTime"@en .
 
 
@@ -632,6 +691,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :Event ;
            rdfs:range xsd:dateTime ;
            rdfs:comment "A date and time value expressed with millisecond precision that indicates when an Event occurred."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "eventTime"@en .
 
 
@@ -641,6 +701,7 @@ xsd:duration rdf:type rdfs:Datatype .
                   rdfs:domain :Result ;
                   rdfs:range xsd:decimal ;
                   rdfs:comment "The number of extra credit points earned by the learner."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                   rdfs:label "extraCreditScore"@en ;
                   owl:deprecated "true"^^xsd:boolean .
 
@@ -655,6 +716,7 @@ xsd:duration rdf:type rdfs:Datatype .
                 ] ;
     rdfs:range xsd:string ;
     rdfs:comment "The Event or Entity identifier.  For an Event, the id MUST be a UUID expressed as a URN using the form urn:uuid:<UUID> per RFC 4122.  For Entities a valid IRI MUST be specified. The IRI MUST be unique and persistent. The IRI SHOULD also be dereferenceable, i.e., capable of returning a representation of the resource.  An Entity MAY be provisioned with a URI employing the URN scheme in cases where a Linked Data friendly HTTP URI is either unavailable or inappropriate."@en ;
+    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
     rdfs:label "id"@en .
 
 
@@ -664,6 +726,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :Frame ;
        rdfs:range xsd:long ;
        rdfs:comment "A non-negative integer that represents the position of the Frame."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "index"@en .
 
 
@@ -673,6 +736,7 @@ xsd:duration rdf:type rdfs:Datatype .
                  rdfs:domain :AssessmentItem ;
                  rdfs:range xsd:boolean ;
                  rdfs:comment "A boolean value indicating whether or not interacting with the item is time dependent."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "isTimeDependent"@en .
 
 
@@ -681,6 +745,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :DigitalResource ;
           rdfs:range xsd:string ;
           rdfs:comment "An ordered collection of one or more string values that represent tags or labels used to identify the resource."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "keywords"@en .
 
 
@@ -690,6 +755,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :DigitalResource ;
              rdfs:range xsd:nonNegativeInteger ;
              rdfs:comment "A non-negative integer indicating the number of permitted attempts."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "maxAttempts"@en .
 
 
@@ -699,6 +765,7 @@ xsd:duration rdf:type rdfs:Datatype .
                 rdfs:domain :Result ;
                 rdfs:range xsd:decimal ;
                 rdfs:comment "The maximum score permitted for a Result."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                 rdfs:label "maxResultScore"@en .
 
 
@@ -712,6 +779,7 @@ xsd:duration rdf:type rdfs:Datatype .
                       ] ;
           rdfs:range xsd:decimal ;
           rdfs:comment "A non-negative integer indicating the maximum score permitted."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "maxScore"@en .
 
 
@@ -721,6 +789,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :DigitalResource ;
             rdfs:range xsd:nonNegativeInteger ;
             rdfs:comment "A non-negative integer indicating the number of permitted submissions."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "maxSubmits"@en .
 
 
@@ -730,6 +799,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :DigitalResource ;
            rdfs:range xsd:string ;
            rdfs:comment "A string value drawn from the list of IANA approved media types and subtypes that identifies the file format of a resource."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "mediaType"@en .
 
 
@@ -739,6 +809,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :AudioObject ;
        rdfs:range xsd:boolean ;
        rdfs:comment "An optional boolean value indicating whether or not the MediaObject has been muted ."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "muted"@en .
 
 
@@ -748,6 +819,7 @@ xsd:duration rdf:type rdfs:Datatype .
       rdfs:domain :Entity ;
       rdfs:range xsd:string ;
       rdfs:comment "A string value comprising a word or phrase by which the resource is known."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "name"@en .
 
 
@@ -757,6 +829,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Result ;
              rdfs:range xsd:decimal ;
              rdfs:comment "The score earned by the learner before adding the extraCreditScore, subtracting the penaltyScore or applying the curveFactor, if any."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "normalScore"@en ;
              owl:deprecated "true"^^xsd:boolean .
 
@@ -766,6 +839,7 @@ xsd:duration rdf:type rdfs:Datatype .
                      owl:FunctionalProperty ;
             rdfs:domain :DigitalResource ;
             rdfs:comment "A string value that designates the resource type."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "objectType"@en ;
             owl:deprecated "true"^^xsd:boolean .
 
@@ -776,6 +850,7 @@ xsd:duration rdf:type rdfs:Datatype .
               rdfs:domain :Result ;
               rdfs:range xsd:decimal ;
               rdfs:comment "The number of points deducted from the normalScore due to an infraction such as submitting an Attempt after the due date."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "penaltyScore"@en ;
               owl:deprecated "true"^^xsd:boolean .
 
@@ -786,6 +861,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :Result ;
              rdfs:range xsd:decimal ;
              rdfs:comment "The result score awarded to the learner.  A result score can be updated."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "resultScore"@en .
 
 
@@ -795,6 +871,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :Score ;
             rdfs:range xsd:decimal ;
             rdfs:comment "The score value."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "scoreGiven"@en .
 
 
@@ -804,6 +881,7 @@ xsd:duration rdf:type rdfs:Datatype .
                rdfs:domain :HighlightAnnotation ;
                rdfs:range xsd:string ;
                rdfs:comment "A string value representing a plain-text rendering of the selected segment of the annotated resource."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "selectionText"@en .
 
 
@@ -813,6 +891,7 @@ xsd:duration rdf:type rdfs:Datatype .
           rdfs:domain :Envelope ;
           rdfs:range xsd:dateTime ;
           rdfs:comment "Envelope send time."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "sendTime"@en .
 
 
@@ -822,6 +901,7 @@ xsd:duration rdf:type rdfs:Datatype .
         rdfs:domain :Envelope ;
         rdfs:range xsd:string ;
         rdfs:comment "Sensor identifier."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "sensor"@en .
 
 
@@ -831,6 +911,7 @@ xsd:duration rdf:type rdfs:Datatype .
        rdfs:domain :TextPositionSelector ;
        rdfs:range xsd:nonNegativeInteger ;
        rdfs:comment "The starting position of a segment of text. The first character in the full text is position 0. The character that represents the start position is included within the selected segment."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "start"@en .
 
 
@@ -845,6 +926,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            ] ;
                rdfs:range xsd:dateTime ;
                rdfs:comment "A date and time value expressed with millisecond precision that describes when the activity commenced."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "startedAtTime"@en .
 
 
@@ -854,6 +936,7 @@ xsd:duration rdf:type rdfs:Datatype .
       rdfs:domain :TagAnnotation ;
       rdfs:range xsd:string ;
       rdfs:comment "An ordered collection of one or more string values that represent labels or tags associated with the annotated DigitalResource."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "tags"@en .
 
 
@@ -863,6 +946,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:domain :Result ;
             rdfs:range xsd:decimal ;
             rdfs:comment "A score earned by the learner equal to the sum of normalScore + extraCreditScore - penaltyScore. This value does not take into account the effects of curving."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "totalScore"@en ;
             owl:deprecated "true"^^xsd:boolean .
 
@@ -877,6 +961,7 @@ xsd:duration rdf:type rdfs:Datatype .
                   ] ;
       rdfs:range xsd:string ;
       rdfs:comment "A string value corresponding to the Class name or label of an Event or Entity."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "type"@en .
 
 
@@ -890,6 +975,7 @@ xsd:duration rdf:type rdfs:Datatype .
                    ] ;
        rdfs:range xsd:string ;
        rdfs:comment "A string value that represents the options selected."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "value"@en .
 
 
@@ -903,6 +989,7 @@ xsd:duration rdf:type rdfs:Datatype .
                     ] ;
         rdfs:range xsd:string ;
         rdfs:comment "An ordered collection of one or more selected options."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "values"@en .
 
 
@@ -916,6 +1003,7 @@ xsd:duration rdf:type rdfs:Datatype .
                      ] ;
          rdfs:range xsd:string ;
          rdfs:comment "A string value that designates the current form or version of the resource."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "version"@en .
 
 
@@ -925,6 +1013,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:domain :AudioObject ;
              rdfs:range xsd:string ;
              rdfs:comment "The current volume level."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "volumeLevel"@en .
 
 
@@ -935,6 +1024,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:range xsd:string ;
            owl:propertyDisjointWith :volumeMin ;
            rdfs:comment "A string value indicating the maximum volume level permitted."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "volumeMax"@en .
 
 
@@ -944,6 +1034,7 @@ xsd:duration rdf:type rdfs:Datatype .
            rdfs:domain :AudioObject ;
            rdfs:range xsd:string ;
            rdfs:comment "A string value indicating the minimum volume level permitted."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "volumeMin"@en .
 
 
@@ -952,13 +1043,17 @@ xsd:duration rdf:type rdfs:Datatype .
 #################################################################
 
 ###  http://purl.imsglobal.org/caliper/Action
-:Action rdf:type owl:Class .
+:Action rdf:type owl:Class ;
+        rdfs:comment "Caliper includes a vocabulary of actions for describing learning interactions. Each action is based on the past-tense form of an English (en-US) verb. An action can also indicate a change in a particular characteristic of the object (e.g., resolution, size, speed, volume).  Each action is also linked to a brief definition (\"gloss\") derived in whole or in part from Princeton University's WordNet® project in order to eliminate ambiguity and aid natural language processing."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
+        rdfs:label "Action"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Agent
 :Agent rdf:type owl:Class ;
        rdfs:subClassOf :Entity ;
        rdfs:comment "A Caliper Agent is a generic type that represents an Entity that can initiate or perform an action.  Utilize Agent only if no suitable subtype exists to represent the actor being described."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Agent"@en .
 
 
@@ -988,6 +1083,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               rdf:type owl:Class
                             ] ;
             rdfs:comment "A Caliper Annotation is a generic type that represents a comment, explanation, highlight, mark, note, question or tag linked to a DigitalResource."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "Annotation"@en .
 
 
@@ -1042,6 +1138,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                    owl:someValuesFrom :Frame
                                  ] ;
                  rdfs:comment "A Caliper AnnotationEvent models the annotating of digital content. The resulting Annotation is also described and is subtyped for greater type specificity."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "AnnotationEvent"@en .
 
 
@@ -1061,6 +1158,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               rdf:type owl:Class
                             ] ;
             rdfs:comment "A Caliper Assessment represents an assessment instrument such as a test or quiz."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "Assessment"@en .
 
 
@@ -1113,6 +1211,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                    owl:someValuesFrom :Attempt
                                  ] ;
                  rdfs:comment "A Caliper AssessmentEvent models learner interactions with assessments instruments such as online tests or quizzes."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "AssessmentEvent"@en .
 
 
@@ -1131,6 +1230,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                   rdf:type owl:Class
                                 ] ;
                 rdfs:comment "A Caliper AssessmentItem represents a single test question."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                 rdfs:label "AssessmentItem"@en .
 
 
@@ -1184,6 +1284,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                        owl:someValuesFrom :AssessmentItem
                                      ] ;
                      rdfs:comment "A Caliper AssessmentItemEvent models a learner's interaction with an individual AssessmentItem."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                      rdfs:label "AssessmentItemEvent"@en .
 
 
@@ -1192,6 +1293,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            rdfs:subClassOf :DigitalResource ;
                            <http://purl.org/dc/terms/isReplacedBy> :DigitalResource ;
                            rdfs:comment "A Caliper AssignableDigitalResource is a generic type that represents digital content associated with a graded or ungraded assignment.  Utilize AssignableDigitalResource only if no suitable subtype exists to represent the resource being described."@en ;
+                           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                            rdfs:label "AssignableDigitalResource"@en .
 
 
@@ -1248,6 +1350,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                    owl:someValuesFrom :Frame
                                  ] ;
                  rdfs:comment "A Caliper AssignableEvent models activities associated with the assignment of digital content assigned to a learner for completion."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "AssignableEvent"@en .
 
 
@@ -1281,6 +1384,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            owl:someValuesFrom :Attempt
                          ] ;
          rdfs:comment "A Caliper Attempt provides a count of the number of times an actor has interacted with an AssignableDigitalResource along with start time, end time and duration information. An Attempt is generated as the result of an action such as starting an Assessment."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "Attempt"@en .
 
 
@@ -1288,6 +1392,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :AudioObject rdf:type owl:Class ;
              rdfs:subClassOf :MediaObject ;
              rdfs:comment "A Caliper AudioObject represents an audio or sound file."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "AudioObject"@en .
 
 
@@ -1295,6 +1400,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :BookmarkAnnotation rdf:type owl:Class ;
                     rdfs:subClassOf :Annotation ;
                     rdfs:comment "A Caliper BookmarkAnnotation represents the act of marking a DigitalResource at a particular location."@en ;
+                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                     rdfs:label "BookmarkAnnotation"@en .
 
 
@@ -1302,6 +1408,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Chapter rdf:type owl:Class ;
          rdfs:subClassOf :DigitalResource ;
          rdfs:comment "A Caliper Chapter represents a major sub-division of a piece of digital content."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "Chapter"@en .
 
 
@@ -1310,6 +1417,7 @@ xsd:duration rdf:type rdfs:Datatype .
                 rdfs:subClassOf :Organization ;
                 owl:disjointWith :Group ;
                 rdfs:comment "A Caliper CourseOffering represents the occurrence of a course or a type during a specified time period."@en ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                 rdfs:label "CourseOffering"@en .
 
 
@@ -1317,6 +1425,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :CourseSection rdf:type owl:Class ;
                rdfs:subClassOf :CourseOffering ;
                rdfs:comment "A Caliper CourseSection represents a specific instance of a CourseOffering occurring during a specific semester, term or period."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "CourseSection"@en .
 
 
@@ -1324,6 +1433,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :DigitalResource rdf:type owl:Class ;
                  rdfs:subClassOf :Entity ;
                  rdfs:comment "A Caliper DigitalResource is a generic type that represents digital content.  Utilize DigitalResource only if no suitable subtype exists to represent the resource being described."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "DigitalResource"@en .
 
 
@@ -1342,6 +1452,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                              rdf:type owl:Class
                                            ] ;
                            rdfs:comment "A Caliper DigitalResourceCollection represents an ordered collection of DigitalResource entities."@en ;
+                           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                            rdfs:label "DigitalResourceCollection"@en .
 
 
@@ -1349,24 +1460,28 @@ xsd:duration rdf:type rdfs:Datatype .
 :Document rdf:type owl:Class ;
           rdfs:subClassOf :DigitalResource ;
           rdfs:comment "A Caliper Document represents paginated textual content."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "Document"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Entity
 :Entity rdf:type owl:Class ;
         rdfs:comment "A Caliper Entity is a generic type that represents objects or things that participate in learning-related activities. Entity is subtyped for enhanced type specificity in order to better describe people, groups, digital content, courses, assignments, assessments, forums, messages, software applications and other entities that constitute the \"stuff\" of a Caliper Event.  Utilize Entity only if no suitable subtype exists to represent the thing being described."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "Entity"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Envelope
 :Envelope rdf:type owl:Class ;
           rdfs:comment "A Caliper Envelope is a container that is used to transmit one or more Caliper Events and/or Caliper Entity describes."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "Envelope"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Event
 :Event rdf:type owl:Class ;
        rdfs:comment "A Caliper Event is a generic type that describes a relationship established between an actor and an object, formed as a result of a purposeful action undertaken by the actor in connection to the object at a particular moment in time."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Event"@en .
 
 
@@ -1374,6 +1489,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :FillinBlankResponse rdf:type owl:Class ;
                      rdfs:subClassOf :Response ;
                      rdfs:comment "A Caliper FillinBlankResponse represents a type of Response in which a respondent is asked to provide one or more words, expressions or short phrases that correctly completes a statement."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                      rdfs:label "FillinBlankResponse"@en .
 
 
@@ -1392,6 +1508,7 @@ xsd:duration rdf:type rdfs:Datatype .
                          rdf:type owl:Class
                        ] ;
        rdfs:comment "A Caliper Forum represents a channel or virtual space in which group discussions take place.  A Forum typically comprises one or more threaded conversations to which members can subscribe, post messages and reply to other messages."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Forum"@en .
 
 
@@ -1436,6 +1553,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               rdf:type owl:Class
                             ] ;
             rdfs:comment "A Caliper ForumEvent models learners and others participating in online forum communities. Forums typically encompass one or more threads or topics to which members can subscribe, post messages and reply to other messages if a threaded discussion is permitted."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "ForumEvent"@en .
 
 
@@ -1443,6 +1561,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Frame rdf:type owl:Class ;
        rdfs:subClassOf :DigitalResource ;
        rdfs:comment "A Caliper Frame represents a part, portion or segment of a DigitalResource."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Frame"@en .
 
 
@@ -1491,6 +1610,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               owl:someValuesFrom :Score
                             ] ;
             rdfs:comment "A Caliper GradeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "GradeEvent"@en .
 
 
@@ -1498,6 +1618,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Group rdf:type owl:Class ;
        rdfs:subClassOf :Organization ;
        rdfs:comment "A Caliper Group represents an ad-hoc, informal or short-lived collection of people organized for some common educational or social purpose.  A Group can act as an Agent. It can be linked both to a parent Organization and to its members."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Group"@en .
 
 
@@ -1505,6 +1626,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :HighlightAnnotation rdf:type owl:Class ;
                      rdfs:subClassOf :Annotation ;
                      rdfs:comment "A Caliper HighlightAnnotation represents the act of marking a particular segment of a DigitalResource between two known coordinates."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                      rdfs:label "HighlightAnnotation"@en .
 
 
@@ -1512,6 +1634,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :ImageObject rdf:type owl:Class ;
              rdfs:subClassOf :MediaObject ;
              rdfs:comment "A Caliper ImageObject represents an image file."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "ImageObject"@en .
 
 
@@ -1519,6 +1642,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :LearningObjective rdf:type owl:Class ;
                    rdfs:subClassOf :Entity ;
                    rdfs:comment "A Caliper LearningObjective represents a brief statement of what a learner should know or be able to perform after completing a unit of instruction or a period of learning."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                    rdfs:label "LearningObjective"@en .
 
 
@@ -1591,6 +1715,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               owl:someValuesFrom :MediaLocation
                             ] ;
             rdfs:comment "A Caliper MediaEvent models interactions between learners and rich content such as audio, images and video."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "MediaEvent"@en .
 
 
@@ -1598,6 +1723,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :MediaLocation rdf:type owl:Class ;
                rdfs:subClassOf :DigitalResource ;
                rdfs:comment "A Caliper MediaLocation provides the current playback position in a MediaObject such as an AudioObject or VideoObject."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "MediaLocation"@en .
 
 
@@ -1605,6 +1731,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :MediaObject rdf:type owl:Class ;
              rdfs:subClassOf :DigitalResource ;
              rdfs:comment "A Caliper MediaObject represents a generic piece of media content.  Utilize MediaObject only if no suitable subtype exists to represent the resource being described."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "MediaObject"@en .
 
 
@@ -1634,6 +1761,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               rdf:type owl:Class
                             ] ;
             rdfs:comment "A Caliper Membership describes the relationship between an Organization and a Person (i.e., a member) in terms of the roles assigned and current status."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "Membership"@en .
 
 
@@ -1652,6 +1780,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            rdf:type owl:Class
                          ] ;
          rdfs:comment "A Caliper Message is a digital form of written communication sent to a recipient. A series of messages may constitute a Thread if they share a common subject and are connected by a reply or by date relationships."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "Message"@en .
 
 
@@ -1697,6 +1826,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                 rdf:type owl:Class
                               ] ;
               rdfs:comment "A Caliper MessageEvent describes a Person posting a Message or marking a post as either read or unread."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "MessageEvent"@en .
 
 
@@ -1704,6 +1834,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :MultipleChoiceResponse rdf:type owl:Class ;
                         rdfs:subClassOf :Response ;
                         rdfs:comment "A Caliper MultipleChoiceResponse represents a type of Response in which a respondent is asked to provide the best possible answer from a list of choices."@en ;
+                        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                         rdfs:label "MultipleChoiceResponse"@en .
 
 
@@ -1711,6 +1842,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :MultipleResponseResponse rdf:type owl:Class ;
                           rdfs:subClassOf :Response ;
                           rdfs:comment "A Caliper MultipleResponseResponse represents a form of response in which a respondent is asked to select more than one correct answer from a list of choices."@en ;
+                          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                           rdfs:label "MultipleResponseResponse"@en .
 
 
@@ -1774,6 +1906,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                    owl:someValuesFrom :Frame
                                  ] ;
                  rdfs:comment "A Caliper NavigationEvent models an actor traversing a network of digital resources."@en ;
+                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                  rdfs:label "NavigationEvent"@en .
 
 
@@ -1781,6 +1914,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Organization rdf:type owl:Class ;
               rdfs:subClassOf :Agent ;
               rdfs:comment "A Caliper Organization represents a formal collection of people organized for some common educational, social or administrative purpose. An Organization can act as an Agent. It can be linked both to a parent Organization and to its members."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "Organization"@en .
 
 
@@ -1837,6 +1971,7 @@ xsd:duration rdf:type rdfs:Datatype .
                               ] ;
               <http://purl.org/dc/terms/isReplacedBy> :GradeEvent ;
               rdfs:comment "A Caliper OutcomeEvent models grading activities performed by an Agent, typically a Person or a SoftwareApplication.  OutcomeEvent is DEPRECATED and will be removed in a future version of the specification. Use GradeEvent instead."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "OutcomeEvent"@en ;
               owl:deprecated "true"^^xsd:boolean .
 
@@ -1845,6 +1980,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Page rdf:type owl:Class ;
       rdfs:subClassOf :DigitalResource ;
       rdfs:comment "A Caliper Page represents an item of paginated content."@en ;
+      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
       rdfs:label "Page"@en .
 
 
@@ -1852,6 +1988,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Person rdf:type owl:Class ;
         rdfs:subClassOf :Agent ;
         rdfs:comment "A Caliper Person represents a human being, alive or deceased, real or imaginary."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "Person"@en .
 
 
@@ -1860,6 +1997,7 @@ xsd:duration rdf:type rdfs:Datatype .
          rdfs:subClassOf :DigitalResource ;
          <http://purl.org/dc/terms/isReplacedBy> :Document ;
          rdfs:comment "A Caliper Reading represents paginated content. Reading is a DEPRECATED entity superseded by Document that will be removed in a future version of the specification. It SHOULD NOT be referenced."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "Reading"@en ;
          owl:deprecated "true"^^xsd:boolean .
 
@@ -1910,6 +2048,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                 owl:someValuesFrom :Frame
                               ] ;
               rdfs:comment "A Caliper ReadingEvent models an actor reading textural content.  ReadingEvent is DEPRECATED and will be removed in a future version of the specification.  It SHOULD NOT be referenced."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "ReadingEvent"@en ;
               owl:deprecated "true"^^xsd:boolean .
 
@@ -1918,6 +2057,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Response rdf:type owl:Class ;
           rdfs:subClassOf :Entity ;
           rdfs:comment "A Caliper Response is a generic type that represents the selected option generated by a Person interacting with an AssessmentItem.  Utilize Response only if no suitable subtype exists to represent the response being described."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "Response"@en .
 
 
@@ -1925,6 +2065,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Result rdf:type owl:Class ;
         rdfs:subClassOf :Entity ;
         rdfs:comment "A Caliper Result represents a grade applied to an assignment submission."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "Result"@en .
 
 
@@ -1939,6 +2080,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :Score rdf:type owl:Class ;
        rdfs:subClassOf :Entity ;
        rdfs:comment "A Caliper Score represents a grade.  The Score value is considered immutable."@en ;
+       rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
        rdfs:label "Score"@en .
 
 
@@ -1946,12 +2088,14 @@ xsd:duration rdf:type rdfs:Datatype .
 :SelectTextResponse rdf:type owl:Class ;
                     rdfs:subClassOf :Response ;
                     rdfs:comment "A Caliper SelectTextResponse represents a type of Response that identifies text or a mapping from a presented paragraph or list."@en ;
+                    rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                     rdfs:label "SelectTextResponse"@en .
 
 
 ###  http://purl.imsglobal.org/caliper/Selector
 :Selector rdf:type owl:Class ;
           rdfs:comment "A Caliper Selector is a generic class that describes a fragment or segment of a resource.  Utilize Selector only if no suitable subtype exists to represent the selection being described."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "Selector"@en .
 
 
@@ -1970,6 +2114,7 @@ xsd:duration rdf:type rdfs:Datatype .
                            rdf:type owl:Class
                          ] ;
          rdfs:comment "A Caliper Session represents a web application user session."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "Session"@en .
 
 
@@ -2042,6 +2187,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                 owl:someValuesFrom :DigitalResource
                               ] ;
               rdfs:comment "A Caliper SessionEvent models the creation and subsequent termination of a user session established by a Person interacting with a SoftwareApplication."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "SessionEvent"@en .
 
 
@@ -2049,6 +2195,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :SharedAnnotation rdf:type owl:Class ;
                   rdfs:subClassOf :Annotation ;
                   rdfs:comment "A Caliper SharedAnnotation represents the act of sharing a reference to a DigitalResource with other agents."@en ;
+                  rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                   rdfs:label "SharedAnnotation"@en .
 
 
@@ -2056,6 +2203,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :SoftwareApplication rdf:type owl:Class ;
                      rdfs:subClassOf :Agent ;
                      rdfs:comment "A Caliper SoftwareApplication represents a computer program, application, module, platform or system."@en ;
+                     rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                      rdfs:label "SoftwareApplication"@en .
 
 
@@ -2070,6 +2218,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :TagAnnotation rdf:type owl:Class ;
                rdfs:subClassOf :Annotation ;
                rdfs:comment "A Caliper TagAnnotation represents the act of tagging a DigitalResource with tags or labels."@en ;
+               rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                rdfs:label "TagAnnotation"@en .
 
 
@@ -2077,6 +2226,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :TextPositionSelector rdf:type owl:Class ;
                       rdfs:subClassOf :Selector ;
                       rdfs:comment "A Caliper TextPositionSelector represents a fragment or selection of textual content, the starting and ending positions of which are determined by the distance in characters from the initial character (position 0) of the enclosing full text."@en ;
+                      rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                       rdfs:label "TextPositionSelector"@en .
 
 
@@ -2106,6 +2256,7 @@ xsd:duration rdf:type rdfs:Datatype .
                           rdf:type owl:Class
                         ] ;
         rdfs:comment "A Caliper Thread represents a series of one or more messages that share a common subject and are connected by a reply or by date relationships."@en ;
+        rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
         rdfs:label "Thread"@en .
 
 
@@ -2150,6 +2301,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                rdf:type owl:Class
                              ] ;
              rdfs:comment "A Caliper ThreadEvent models an actor interacting with a Forum thread or topic."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "ThreadEvent"@en .
 
 
@@ -2194,6 +2346,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                 owl:someValuesFrom :SoftwareApplication
                               ] ;
               rdfs:comment "A Caliper ToolUseEvent models a Person using a learning tool in a way that the tool's creators have determined is an indication of a learning interaction."@en ;
+              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
               rdfs:label "ToolUseEvent"@en .
 
 
@@ -2201,6 +2354,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :TrueFalseResponse rdf:type owl:Class ;
                    rdfs:subClassOf :Response ;
                    rdfs:comment "A Caliper TrueFalseResponse represents a type of Response to an AssessmentItem in which only two possible options are provided (e.g., true/false, yes/no)."@en ;
+                   rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                    rdfs:label "TrueFalseResponse"@en .
 
 
@@ -2208,6 +2362,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :VideoObject rdf:type owl:Class ;
              rdfs:subClassOf :MediaObject ;
              rdfs:comment "A Caliper VideoObject represents a visual recording stored in digital form."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "VideoObject"@en .
 
 
@@ -2252,6 +2407,7 @@ xsd:duration rdf:type rdfs:Datatype .
                              owl:someValuesFrom :Frame
                            ] ;
            rdfs:comment "A Caliper ViewEvent describes an actor's examination of digital content whenever the activity emphasizes thoughtful observation or study as opposed to the mere retrieval of a resource."@en ;
+           rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
            rdfs:label "ViewEvent"@en .
 
 
@@ -2259,6 +2415,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :WebPage rdf:type owl:Class ;
          rdfs:subClassOf :DigitalResource ;
          rdfs:comment "A Caliper WebPage represents a document containing markup that is suitable for display in a web browser."@en ;
+         rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
          rdfs:label "WebPage"@en .
 
 
@@ -2267,6 +2424,7 @@ xsd:duration rdf:type rdfs:Datatype .
              rdfs:subClassOf :DigitalResource ;
              <http://purl.org/dc/terms/isReplacedBy> :Chapter ;
              rdfs:comment "A Caliper EpubChapter represents a major structural division of a piece of writing. EpubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."@en ;
+             rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
              rdfs:label "EpubChapter"@en ;
              owl:deprecated "true"^^xsd:boolean .
 
@@ -2275,6 +2433,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :epubPart rdf:type owl:Class ;
           rdfs:subClassOf :DigitalResource ;
           rdfs:comment "A Caliper EpubPart represents a major structural division of a piece of writing, typically encapsulating a set of related chapters. EpubPart is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."@en ;
+          rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
           rdfs:label "EpubPart"@en ;
           owl:deprecated "true"^^xsd:boolean .
 
@@ -2294,6 +2453,7 @@ xsd:duration rdf:type rdfs:Datatype .
                                   rdf:type owl:Class
                                 ] ;
                 rdfs:comment "A Caliper EpubSubChapter represents a major sub-division of an EpubChapter. EpubSubChapter is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."^^xsd:string ;
+                rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
                 rdfs:label "EpubSubChapter"@en ;
                 owl:deprecated "true"^^xsd:boolean .
 
@@ -2303,6 +2463,7 @@ xsd:duration rdf:type rdfs:Datatype .
             rdfs:subClassOf :DigitalResource ;
             <http://purl.org/dc/terms/isReplacedBy> :Document ;
             rdfs:comment "A Caliper EpubVolume represents a component of a collection. EpubVolume inherits all the properties and requirements defined for DigitalResource, its supertype. EpubVolume is a DEPRECATED entity that will be removed in a future version of the specification. It SHOULD NOT be referenced."@en ;
+            rdfs:isDefinedBy "http://purl.imsglobal.org/caliper" ;
             rdfs:label "EpubVolume"@en ;
             owl:deprecated "true"^^xsd:boolean .
 


### PR DESCRIPTION
This PR plays off knowledge and advice gained from attending Stanford's Protege short course held during the last week of March 2018.  [1]   Below is a summary of adjustments to the ontology:

1.  More fully describe `Event` subtypes as well as certain entities such as `Attempt` and `Membership` by adding additional class expressions, including value restrictions.

Example: `AssessmentItemEvent`
```
(actor some Agent) and (actor only Person)
(action some Action) and (action some ({Completed , Skipped , Started}))
(object some DigitalResource) and (object only AssessmentItem)
. . .
```
2.  Add the various `Action`, `Role` and `Status` values as named individuals or instances, tweeking the range values of the object properties `action`, `roles` and `status` appropriately.

3.  Define Disjoint class axioms as well as owl:Different annotations for named individuals 

4.  Adds rdfs:comment and rdfs:definedBy annotations when appropriate for all terms.

[1] https://protege.stanford.edu/shortcourse/201803/ 