### PR TITLE
Change metricValue and maxMetricValue range to xsd:decimal

### DIFF
--- a/caliper-jsonld.owl
+++ b/caliper-jsonld.owl
@@ -7511,7 +7511,7 @@
     "@value" : "maxMetricValue"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
-    "@id" : "http://www.w3.org/2001/XMLSchema#integer"
+    "@id" : "http://www.w3.org/2001/XMLSchema#decimal"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/maxResultScore",
@@ -7763,7 +7763,7 @@
     "@value" : "metricValue"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#range" : [ {
-    "@id" : "http://www.w3.org/2001/XMLSchema#integer"
+    "@id" : "http://www.w3.org/2001/XMLSchema#decimal"
   } ]
 }, {
   "@id" : "http://purl.imsglobal.org/caliper/metrics/AssessmentsPassed",

--- a/caliper-rdfxml.owl
+++ b/caliper-rdfxml.owl
@@ -1246,7 +1246,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
 
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/maxMetricValue">
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AggregateMeasure"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">An integer value representing the total possible curricular progress the actor can make in the context of the application.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">maxMetricValue</rdfs:label>
@@ -1358,7 +1358,7 @@ The Caliper ontology provides a machine-readable document that defines the conce
     <owl:DatatypeProperty rdf:about="http://purl.imsglobal.org/caliper/metricValue">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="http://purl.imsglobal.org/caliper/AggregateMeasure"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
         <rdfs:comment xml:lang="en">An integer value representing the total curricular progress the actor has made in the context of the application.</rdfs:comment>
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.imsglobal.org/caliper</rdfs:isDefinedBy>
         <rdfs:label xml:lang="en">metricValue</rdfs:label>

--- a/caliper-turtle.owl
+++ b/caliper-turtle.owl
@@ -925,7 +925,7 @@ xsd:duration rdf:type rdfs:Datatype .
 ###  http://purl.imsglobal.org/caliper/maxMetricValue
 :maxMetricValue rdf:type owl:DatatypeProperty ;
                 rdfs:domain :AggregateMeasure ;
-                rdfs:range xsd:integer ;
+                rdfs:range xsd:decimal ;
                 rdfs:comment "An integer value representing the total possible curricular progress the actor can make in the context of the application."@en ;
                 rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
                 rdfs:label "maxMetricValue"@en .
@@ -1010,7 +1010,7 @@ xsd:duration rdf:type rdfs:Datatype .
 :metricValue rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              rdfs:domain :AggregateMeasure ;
-             rdfs:range xsd:integer ;
+             rdfs:range xsd:decimal ;
              rdfs:comment "An integer value representing the total curricular progress the actor has made in the context of the application."@en ;
              rdfs:isDefinedBy "http://purl.imsglobal.org/caliper"^^xsd:string ;
              rdfs:label "metricValue"@en .


### PR DESCRIPTION
The range for `metricValue` and `maxMetricValue` is currently (and incorrectly) described as xsd:integer.  Change to xsd:decimal.